### PR TITLE
Fixes percona/galera#7 - Incorrect error message in garb_logger

### DIFF
--- a/galera/src/mapped_buffer.cpp
+++ b/galera/src/mapped_buffer.cpp
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include <limits>
 
@@ -96,10 +97,11 @@ void galera::MappedBuffer::reserve(size_t sz)
                                  fd_, 0)));
             if (tmp == MAP_FAILED)
             {
+                int dummy_errno = errno;
                 free(buf_);
                 buf_ = 0;
                 clear();
-                gu_throw_error(ENOMEM) << "mmap() failed";
+                gu_throw_error(dummy_errno) << "mmap() failed";
             }
             copy(buf_, buf_ + buf_size_, tmp);
             free(buf_);
@@ -119,9 +121,10 @@ void galera::MappedBuffer::reserve(size_t sz)
                             mmap(NULL, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd_, 0)));
             if (tmp == MAP_FAILED)
             {
+                int dummy_errno = errno;
                 buf_ = 0;
                 clear();
-                gu_throw_error(ENOMEM) << "mmap() failed";
+                gu_throw_error(dummy_errno) << "mmap() failed";
             }
             buf_ = tmp;
         }
@@ -132,7 +135,7 @@ void galera::MappedBuffer::reserve(size_t sz)
         byte_t* tmp(reinterpret_cast<byte_t*>(realloc(buf_, sz)));
         if (tmp == 0)
         {
-            gu_throw_error(ENOMEM) << "realloc failed";
+            gu_throw_error(errno) << "realloc failed";
         }
         buf_ = tmp;
     }

--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -12,6 +12,7 @@ namespace po = boost::program_options;
 
 #include <iostream>
 #include <fstream>
+#include <errno.h>
 
 namespace garb
 {
@@ -88,7 +89,7 @@ Config::Config (int argc, char* argv[])
 
         if (!ifs.good())
         {
-            gu_throw_error(ENOENT)
+            gu_throw_error(errno)
                 << "Failed to open configuration file '" << cfg_
                 << "' for reading.";
         }

--- a/garb/garb_logger.cpp
+++ b/garb/garb_logger.cpp
@@ -3,7 +3,7 @@
 #include "garb_logger.hpp"
 
 #include <cstdio>
-
+#include <errno.h>
 #include <syslog.h>
 
 namespace garb
@@ -14,8 +14,8 @@ namespace garb
 
         if (!log_file)
         {
-            gu_throw_error (ENOENT) << "Failed to open '" << fname
-                                    << "' for appending";
+            gu_throw_error (errno) << "Failed to open '" << fname
+                                   << "' for appending";
         }
 
         gu_conf_set_log_file (log_file);


### PR DESCRIPTION
Replace hard-coded error codes with errno in a number of places. This is
mostly to report the actual error on fopen(), other changes are purely
cosmetic.
