### PR TITLE
PXC-318: Typo in wsrep_provider_options causes an unhandled exception

### DIFF
--- a/galera/src/replicator_smm_params.cpp
+++ b/galera/src/replicator_smm_params.cpp
@@ -125,7 +125,10 @@ galera::ReplicatorSMM::ParseOptions::ParseOptions(Replicator&       repl,
                                                   gu::Config&       conf,
                                                   const char* const opts)
 {
-    conf.parse(opts);
+    try {
+        conf.parse(opts);
+    }
+    catch (gu::NotFound) {}
     // Set initial wsrep params here to enable debug logging etc
     // for the rest of the initialization
     wsrep_set_params(repl, opts);

--- a/galera/src/wsrep_params.cpp
+++ b/galera/src/wsrep_params.cpp
@@ -61,7 +61,7 @@ wsrep_set_params (galera::Replicator& repl, const char* params)
         catch (gu::NotFound&)
         {
             log_warn << "Unknown parameter '" << key << "'";
-            gu_throw_error(EINVAL) << "Unknown parameter' " << key << "'";
+            gu_throw_error(EINVAL) << "Unknown parameter '" << key << "'";
         }
         catch (gu::Exception& e)
         {


### PR DESCRIPTION
Fixes percona/galera#10.

Catch gu::NotFound so we don’t abort with unhandled exception on syntax
errors.
