### PR TITLE
PXC-317: Interrupted IST results in HA_ERR_KEY_NOT_FOUND in subsequent IST

### DIFF
--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -621,7 +621,6 @@ ReplicatorSMM::send_state_request (const StateRequest* const req)
         sst_state_ = SST_REQ_FAILED;
 
         st_.set(state_uuid_, STATE_SEQNO());
-        st_.mark_safe();
 
         if (state_() > S_CLOSING)
         {
@@ -634,6 +633,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req)
         else
         {
             // connection is being closed, send failure is expected
+            st_.mark_safe();
         }
     }
 }


### PR DESCRIPTION
Fixes percona/galera#9.

Do not mark the state file as safe when state transfer request has
failed unrecoverably.
