### PR TITLE
PXC-122: Better instrumentation of memory usage of galera

### DIFF
--- a/galera/src/certification.hpp
+++ b/galera/src/certification.hpp
@@ -105,6 +105,12 @@ namespace galera
             index_size_ = 0;
         }
 
+        size_t bucket_count ()
+        {
+            return cert_index_.bucket_count() +
+                cert_index_ng_.bucket_count();
+        }
+
         bool index_purge_required()
         {
             register long const count(key_count_.fetch_and_zero());

--- a/galera/src/replicator.hpp
+++ b/galera/src/replicator.hpp
@@ -111,7 +111,7 @@ namespace galera
         virtual void process_join(wsrep_seqno_t seqno, wsrep_seqno_t seqno_l) = 0;
         virtual void process_sync(wsrep_seqno_t seqno_l) = 0;
 
-        virtual const struct wsrep_stats_var* stats_get() const = 0;
+        virtual const struct wsrep_stats_var* stats_get() = 0;
         virtual void                          stats_reset() = 0;
         // static void stats_free(struct wsrep_stats_var*) must be declared in
         // the child class

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -134,7 +134,7 @@ namespace galera
         void process_join(wsrep_seqno_t seqno, wsrep_seqno_t seqno_l);
         void process_sync(wsrep_seqno_t seqno_l);
 
-        const struct wsrep_stats_var* stats_get()  const;
+        const struct wsrep_stats_var* stats_get();
         void                          stats_reset();
         void                   stats_free(struct wsrep_stats_var*);
 

--- a/galera/src/replicator_smm_stats.cpp
+++ b/galera/src/replicator_smm_stats.cpp
@@ -110,6 +110,8 @@ typedef enum status_vars
     STATS_LOCAL_STATE,
     STATS_LOCAL_STATE_COMMENT,
     STATS_CERT_INDEX_SIZE,
+    STATS_CERT_BUCKET_COUNT,
+    STATS_GCACHE_POOL_SIZE,
     STATS_CAUSAL_READS,
     STATS_CERT_INTERVAL,
     STATS_INCOMING_LIST,
@@ -155,6 +157,8 @@ static const struct wsrep_stats_var wsrep_stats[STATS_MAX + 1] =
     { "local_state",              WSREP_VAR_INT64,  { 0 }  },
     { "local_state_comment",      WSREP_VAR_STRING, { 0 }  },
     { "cert_index_size",          WSREP_VAR_INT64,  { 0 }  },
+    { "cert_bucket_count",        WSREP_VAR_INT64,  { 0 }  },
+    { "gcache_pool_size",         WSREP_VAR_INT64,  { 0 }  },
     { "causal_reads",             WSREP_VAR_INT64,  { 0 }  },
     { "cert_interval",            WSREP_VAR_DOUBLE, { 0 }  },
     { "incoming_addresses",       WSREP_VAR_STRING, { 0 }  },
@@ -177,7 +181,7 @@ galera::ReplicatorSMM::build_stats_vars (
 }
 
 const struct wsrep_stats_var*
-galera::ReplicatorSMM::stats_get() const
+galera::ReplicatorSMM::stats_get()
 {
     if (S_DESTROYED == state_()) return 0;
 
@@ -226,6 +230,9 @@ galera::ReplicatorSMM::stats_get() const
     sv[STATS_CERT_DEPS_DISTANCE  ].value._double = avg_deps_dist;
     sv[STATS_CERT_INTERVAL       ].value._double = avg_cert_interval;
     sv[STATS_CERT_INDEX_SIZE     ].value._int64 = index_size;
+    sv[STATS_CERT_BUCKET_COUNT   ].value._int64 = cert_.bucket_count();
+
+    sv[STATS_GCACHE_POOL_SIZE    ].value._int64 = gcache_.actual_pool_size();
 
     double oooe;
     double oool;

--- a/galerautils/src/gu_mmap.hpp
+++ b/galerautils/src/gu_mmap.hpp
@@ -39,4 +39,7 @@ private:
 
 } /* namespace gu */
 
+/** Returns actual memory usage by allocated page range: **/
+size_t gu_actual_memory_usage (const void * const ptr, const size_t length);
+
 #endif /* __GCACHE_MMAP__ */

--- a/galerautils/src/gu_unordered.hpp
+++ b/galerautils/src/gu_unordered.hpp
@@ -96,9 +96,7 @@ namespace gu
         bool empty() const { return impl_.empty(); }
         void clear() { impl_.clear(); }
         void rehash(size_t n) { impl_.rehash(n); }
-#if defined(HAVE_UNORDERED_MAP)
-        void reserve(size_t n) { impl_.reserve(n); }
-#endif
+        size_t bucket_count() { return impl_.bucket_count(); }
     };
 
 
@@ -141,6 +139,10 @@ namespace gu
         bool empty() const { return impl_.empty(); }
         void clear() { impl_.clear(); }
         void rehash(size_t n) { impl_.rehash(n); }
+#if defined(HAVE_UNORDERED_MAP)
+        void reserve(size_t n) { impl_.reserve(n); }
+#endif
+        size_t bucket_count() { return impl_.bucket_count(); }
     };
 
     template <typename K, typename V, typename H = UnorderedHash<K> >
@@ -178,6 +180,10 @@ namespace gu
         void erase(iterator i) { impl_.erase(i); }
         size_t size() const { return impl_.size(); }
         bool empty() const { return impl_.empty(); }
+#if defined(HAVE_UNORDERED_MAP)
+        void reserve(size_t n) { impl_.reserve(n); }
+#endif
+        size_t bucket_count() { return impl_.bucket_count(); }
     };
 }
 

--- a/gcache/src/GCache.cpp
+++ b/gcache/src/GCache.cpp
@@ -70,6 +70,14 @@ namespace gcache
                   << "\n" << "GCache frees   : " << frees;
     }
 
+    size_t GCache::actual_pool_size ()
+    {
+        gu::Lock lock(mtx);
+        return mem.actual_pool_size() +
+               rb.actual_pool_size() +
+               ps.actual_pool_size();
+    }
+
     /*! prints object properties */
     void print (std::ostream& os) {}
 }

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -96,6 +96,11 @@ namespace gcache
                                    int64_t& seqno_d,
                                    ssize_t& size);
 
+        /*!
+         * Returns actual gcache memory pool size (in bytes).
+         */
+        size_t actual_pool_size ();
+
         class Buffer
         {
         public:

--- a/gcache/src/gcache_mem_store.cpp
+++ b/gcache/src/gcache_mem_store.cpp
@@ -4,6 +4,7 @@
 
 #include "gcache_mem_store.hpp"
 #include "gcache_page_store.hpp"
+#include "gcache_rb_store.hpp"
 
 namespace gcache
 {
@@ -58,7 +59,7 @@ MemStore::seqno_reset()
     {
         std::set<void*>::iterator tmp(buf); ++buf;
 
-        BufferHeader* const bh(ptr2BH(*tmp));
+        BufferHeader* const bh(BH_cast(*tmp));
 
         if (bh->seqno_g != SEQNO_NONE)
         {
@@ -70,6 +71,38 @@ MemStore::seqno_reset()
             ::free (bh);
         }
     }
+}
+
+size_t MemStore::actual_pool_size ()
+{
+  size_t size= 0;
+  for (std::set<void*>::iterator buf(allocd_.begin());
+                                 buf != allocd_.end(); ++buf)
+  {
+    BufferHeader* const bh(static_cast<BufferHeader*>(*buf));
+    switch (bh->store)
+    {
+      case BUFFER_IN_MEM:
+        size += bh->size;
+        break;
+      case BUFFER_IN_RB:
+        {
+          RingBuffer* const rb (static_cast<RingBuffer*>(bh->ctx));
+          size += rb->actual_pool_size();
+          break;
+        }
+      case BUFFER_IN_PAGE:
+        {
+          Page* const page (static_cast<Page*>(bh->ctx));
+          size += page->actual_pool_size();
+          break;
+        }
+      default:
+        log_fatal << "Corrupt buffer header: " << bh;
+        abort();
+    }
+  }
+  return size;
 }
 
 } /* namespace gcache */

--- a/gcache/src/gcache_mem_store.hpp
+++ b/gcache/src/gcache_mem_store.hpp
@@ -134,6 +134,8 @@ namespace gcache
         // for unit tests only
         ssize_t _allocd () const { return size_; }
 
+        size_t actual_pool_size ();
+
     private:
 
         bool have_free_space (ssize_t size);

--- a/gcache/src/gcache_page.cpp
+++ b/gcache/src/gcache_page.cpp
@@ -144,3 +144,8 @@ gcache::Page::realloc (void* ptr, ssize_t size)
         }
     }
 }
+
+size_t gcache::Page::actual_pool_size ()
+{
+    return gu_actual_memory_usage((void *) mmap_.ptr, mmap_.size);
+}

--- a/gcache/src/gcache_page.hpp
+++ b/gcache/src/gcache_page.hpp
@@ -54,6 +54,8 @@ namespace gcache
 
         void* parent() const { return ps_; }
 
+        size_t actual_pool_size ();
+
     private:
 
         gu::FileDescriptor fd_;

--- a/gcache/src/gcache_page_store.cpp
+++ b/gcache/src/gcache_page_store.cpp
@@ -254,3 +254,16 @@ gcache::PageStore::realloc (void* ptr, ssize_t size)
 
     return ret;
 }
+
+size_t gcache::PageStore::actual_pool_size ()
+{
+  size_t size = 0;
+  std::deque<Page*>::iterator ptr = pages_.begin();
+  while (ptr != pages_.end())
+  {
+    Page* page = static_cast<Page*>(*ptr);
+    size += page->actual_pool_size();
+    ptr++;
+  }
+  return size;
+}

--- a/gcache/src/gcache_page_store.hpp
+++ b/gcache/src/gcache_page_store.hpp
@@ -52,6 +52,8 @@ namespace gcache
 
         void  set_keep_size (ssize_t size) { keep_size_ = size; }
 
+        size_t actual_pool_size ();
+
     private:
 
         std::string const base_name_; /* /.../.../gcache.page. */

--- a/gcache/src/gcache_params.cpp
+++ b/gcache/src/gcache_params.cpp
@@ -67,6 +67,11 @@ gcache::GCache::Params::Params (gu::Config& cfg, const std::string& data_dir)
         log_error << "Negative page buffer size";
     }
 
+    if (rb_size_ < 0)
+    {
+        log_error << "Negative ring buffer size";
+    }
+
     if (mem_size_ < 0)
     {
         log_error << "Negative memory buffer size";

--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -469,6 +469,11 @@ namespace gcache
         assert_sizes();
     }
 
+    size_t RingBuffer::actual_pool_size ()
+    {
+       return gu_actual_memory_usage((void *) mmap_.ptr, mmap_.size);
+    }
+
     void RingBuffer::print (std::ostream& os) const
     {
         os  << "\nstart_ : " << reinterpret_cast<void*>(start_)

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -101,6 +101,8 @@ namespace gcache
             assert_size_free();
         }
 
+        size_t actual_pool_size ();
+
     private:
 
         static ssize_t const PREAMBLE_LEN = 1024;


### PR DESCRIPTION
PXC-122: Better instrumentation of memory usage of galera
PXC-372: Memory access beyond the allocated block in the seqno_reset() function

Added 2 new status variables: wsrep_cert_bucket_count and
wsrep_gcache_pool_size. Also fixed an out-of-bount memory access issue
in MemStore::seqno_reset().
