### PR TITLE
Fix for release string for galera rpm package (JEN-342)

### DIFF
--- a/packages/rpm/percona-xtradb-cluster-galera.spec
+++ b/packages/rpm/percona-xtradb-cluster-galera.spec
@@ -77,7 +77,7 @@ Prefix: %{_prefix}
 
 Name:		Percona-XtraDB-Cluster-galera-3
 Version:	%{galera_version}
-Release:	1.%{pxcg_revision}.%{?distribution}
+Release:	%{pxcg_revision}.%{?distribution}
 Summary:	Galera libraries of Percona XtraDB Cluster
 Group:		Applications/Databases
 License:	GPLv3


### PR DESCRIPTION
This change is about fixing versions and release strings after moving to git.
As proposed in JEN-342 we'll:
remove "1." in release string - and we'll define pxcg_revision as $GALERA_RPM_RELEASE in jenkins job
