### PR TITLE
5.5 - Fix for release string for galera rpm package (JEN-342)

### DIFF
--- a/scripts/packages/percona-xtradb-cluster-galera.spec
+++ b/scripts/packages/percona-xtradb-cluster-galera.spec
@@ -77,7 +77,7 @@ Prefix: %{_prefix}
 
 Name:		Percona-XtraDB-Cluster-galera-2
 Version:	%{galera_version}
-Release:	1.%{pxcg_revision}.%{?distribution}
+Release:	%{pxcg_revision}.%{?distribution}
 Summary:	Galera libraries of Percona XtraDB Cluster
 Group:		Applications/Databases
 License:	GPLv3


### PR DESCRIPTION
Same thing as we did for 5.6/3.x.
This change is about fixing versions and release strings after moving to git.
As proposed in JEN-342 we'll:
remove "1." in release string - and we'll define pxcg_revision as $GALERA_RPM_RELEASE in jenkins job
