### PR TITLE
- PXC-445: Follow-up fixes to Percona's galera plugin codebase as par…

### DIFF
--- a/gcache/src/gcache_page.hpp
+++ b/gcache/src/gcache_page.hpp
@@ -42,7 +42,7 @@ namespace gcache
 
         size_t used () const { return used_; }
 
-        size_t size() const { return fd_.size(); } /* size on storage */
+        size_t size() const { return size_; } /* size on storage */
 
         const std::string& name() const { return fd_.name(); }
 

--- a/gcache/src/gcache_params.cpp
+++ b/gcache/src/gcache_params.cpp
@@ -64,7 +64,7 @@ gcache::GCache::Params::Params (gu::Config& cfg, const std::string& data_dir)
     rb_size_  (cfg.get<size_t>(GCACHE_PARAMS_RB_SIZE)),
     page_size_(cfg.get<size_t>(GCACHE_PARAMS_PAGE_SIZE)),
     keep_pages_size_(cfg.get<size_t>(GCACHE_PARAMS_KEEP_PAGES_SIZE)),
-    keep_pages_count_(cfg.get<size_t>(GCACHE_PARAMS_KEEP_PAGES_SIZE))
+    keep_pages_count_(cfg.get<size_t>(GCACHE_PARAMS_KEEP_PAGES_COUNT))
 {
     if (mem_size_)
     {


### PR DESCRIPTION
…t of merge

  conflict resolution.

  After recent merge of galera plugin branch to PXC repos few merge conflicts
  were identified. They were fixed using the best possible decision then
  with this ticket to re-review the decision.

  Patch fixes the merge conflict taking into consideration fixes specific to
  PXC repos.

  a. gcache::Page::size() function in PXC repos is optimized to return page size
  directly from a cached variable vs calculating it from file descriptor.

  b. keep_page_count_ was wrongly being initialized to keep_page_size_.

  c. Comment added in cleanup to clarify the cleanup conditions.
