### PR TITLE
- PXC#393: Optimized and accurate way to get mmap file gcache size us…

### DIFF
--- a/common/wsrep_api.h
+++ b/common/wsrep_api.h
@@ -983,6 +983,15 @@ struct wsrep {
     struct wsrep_stats_var* (*stats_get) (wsrep_t* wsrep);
 
   /*!
+   * @brief Returns an array of extended status variables.
+   *        Array is terminated by Null variable name.
+   *
+   * @param wsrep provider handle
+   * @return array of struct wsrep_status_var.
+   */
+    struct wsrep_stats_var* (*stats_ext_get) (wsrep_t* wsrep);
+
+  /*!
    * @brief Release resources that might be associated with the array.
    *
    * @param wsrep     provider handle.

--- a/galera/src/replicator.hpp
+++ b/galera/src/replicator.hpp
@@ -112,6 +112,7 @@ namespace galera
         virtual void process_sync(wsrep_seqno_t seqno_l) = 0;
 
         virtual const struct wsrep_stats_var* stats_get() = 0;
+        virtual const struct wsrep_stats_var* stats_ext_get() = 0;
         virtual void                          stats_reset() = 0;
         // static void stats_free(struct wsrep_stats_var*) must be declared in
         // the child class

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -199,7 +199,8 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     preordered_id_      (),
     incoming_list_      (""),
     incoming_mutex_     (),
-    wsrep_stats_        ()
+    wsrep_stats_        (),
+    wsrep_stats_ext_    ()
 {
     // @todo add guards (and perhaps actions)
     state_.add_transition(Transition(S_CLOSED,  S_DESTROYED));
@@ -271,6 +272,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     cert_.assign_initial_position(seqno, trx_proto_ver());
 
     build_stats_vars(wsrep_stats_);
+    build_stats_ext_vars(wsrep_stats_ext_);
 }
 
 galera::ReplicatorSMM::~ReplicatorSMM()

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -135,6 +135,7 @@ namespace galera
         void process_sync(wsrep_seqno_t seqno_l);
 
         const struct wsrep_stats_var* stats_get();
+        const struct wsrep_stats_var* stats_ext_get();
         void                          stats_reset();
         void                   stats_free(struct wsrep_stats_var*);
 
@@ -452,6 +453,7 @@ namespace galera
         };
 
         void build_stats_vars (std::vector<struct wsrep_stats_var>& stats);
+        void build_stats_ext_vars (std::vector<struct wsrep_stats_var>& stats);
 
         void establish_protocol_versions (int version);
 
@@ -618,6 +620,7 @@ namespace galera
         mutable gu::Mutex     incoming_mutex_;
 
         mutable std::vector<struct wsrep_stats_var> wsrep_stats_;
+        mutable std::vector<struct wsrep_stats_var> wsrep_stats_ext_;
     };
 
     std::ostream& operator<<(std::ostream& os, ReplicatorSMM::State state);

--- a/galera/src/replicator_smm_stats.cpp
+++ b/galera/src/replicator_smm_stats.cpp
@@ -339,6 +339,78 @@ galera::ReplicatorSMM::stats_get()
     return buf;
 }
 
+typedef enum status_vars_ext
+{
+    STATS_EXT_GCACHE_ACTUAL_POOL_SIZE = 0,
+    STATS_EXT_MAX
+} StatusExtVars;
+
+static const struct wsrep_stats_var wsrep_stats_ext[STATS_EXT_MAX + 1] =
+{
+    { "gcache_actual_pool_size",  WSREP_VAR_INT64,  { 0 }  },
+    { 0,                          WSREP_VAR_STRING, { 0 }  }
+};
+
+void
+galera::ReplicatorSMM::build_stats_ext_vars (
+    std::vector<struct wsrep_stats_var>& stats)
+{
+    const struct wsrep_stats_var* ptr(wsrep_stats_ext);
+
+    do
+    {
+        stats.push_back(*ptr);
+    }
+    while (ptr++->name != 0);
+
+    stats[STATS_EXT_GCACHE_ACTUAL_POOL_SIZE].value._int64 = 0;
+}
+
+const struct wsrep_stats_var*
+galera::ReplicatorSMM::stats_ext_get()
+{
+    if (S_DESTROYED == state_()) return 0;
+
+    std::vector<struct wsrep_stats_var> sv(wsrep_stats_ext_);
+
+    sv[STATS_EXT_GCACHE_ACTUAL_POOL_SIZE].value._int64 =
+       gcache_.actual_pool_size();
+
+    /* Create a buffer to be passed to the caller. */
+    // The buffer size needed:
+    // * Space for wsrep_stats_ext_ array
+    // * Trailing space for string store
+    size_t const vec_size(
+        (sv.size())*sizeof(struct wsrep_stats_var));
+    struct wsrep_stats_var* const buf(
+        reinterpret_cast<struct wsrep_stats_var*>(
+            gu_malloc(vec_size)));
+
+    if (buf)
+    {
+        size_t sv_pos(STATS_EXT_MAX);
+
+        assert(sv_pos == sv.size() - 1);
+
+        // NULL terminate
+        sv[sv_pos].name = 0;
+        sv[sv_pos].type = WSREP_VAR_STRING;
+        sv[sv_pos].value._string = 0;
+
+        // Finally copy sv vector to buf
+        memcpy(buf, &sv[0], vec_size);
+    }
+    else
+    {
+        log_warn << "Failed to allocate extended stats vars buffer to "
+                 << (vec_size)
+                 << " bytes. System is running out of memory.";
+
+    }
+
+    return buf;
+}
+
 void
 galera::ReplicatorSMM::stats_reset()
 {

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -922,6 +922,18 @@ struct wsrep_stats_var* galera_stats_get (wsrep_t* gh)
 
 
 extern "C"
+struct wsrep_stats_var* galera_stats_ext_get (wsrep_t* gh)
+{
+    assert(gh != 0);
+    assert(gh->ctx != 0);
+
+    REPL_CLASS* repl(reinterpret_cast< REPL_CLASS * >(gh->ctx));
+
+    return const_cast<struct wsrep_stats_var*>(repl->stats_ext_get());
+}
+
+
+extern "C"
 void galera_stats_free (wsrep_t* gh, struct wsrep_stats_var* s)
 {
     assert(gh != 0);
@@ -1090,6 +1102,7 @@ static wsrep_t galera_str = {
     &galera_sst_received,
     &galera_snapshot,
     &galera_stats_get,
+    &galera_stats_ext_get,
     &galera_stats_free,
     &galera_stats_reset,
     &galera_pause,

--- a/galerautils/src/gu_mmap.cpp
+++ b/galerautils/src/gu_mmap.cpp
@@ -100,3 +100,100 @@ namespace gu
         if (mapped) unmap();
     }
 }
+
+/** Returns actual memory usage by allocated page range: **/
+
+/*
+ * Verify test macros to make sure we have mincore syscall:
+ */
+#if defined(_BSD_SOURCE) || defined(_SVID_SOURCE)
+
+/*
+ * The buffer size for mincore. 256 kilobytes is enough to request
+ * information on the status of 1GB memory map (256K * 4096 bytes per
+ * page = 1GB) in one syscall (when a 4096-byte pages). Increasing this
+ * parameter allows us to save a few syscalls (when huge amounts of mmap),
+ * but it also raises the memory requirements for temporary buffer:
+ */
+#define GU_AMU_CHUNK 0x40000 /* Currently 256K, must be power of two. */
+
+size_t gu_actual_memory_usage (const void * const ptr, const size_t length)
+{
+    size_t size= 0;
+    if (length)
+    {
+        /*
+         * -PAGE_SIZE is same as ~(PAGE_SIZE-1), but creates less
+         * potential problems due to implicit type cast in expressions:
+         */
+        uintptr_t first=
+            reinterpret_cast<uintptr_t> (ptr) & -GU_PAGE_SIZE;
+        const uintptr_t last=
+           (reinterpret_cast<uintptr_t> (ptr) + length - 1) & -GU_PAGE_SIZE;
+        const ptrdiff_t total=  last - first + GU_PAGE_SIZE;
+        size_t          pages=  total / GU_PAGE_SIZE;
+        size_t          chunks= pages / GU_AMU_CHUNK;
+        unsigned char * const map=
+            reinterpret_cast<unsigned char *> (malloc(chunks ? GU_AMU_CHUNK : pages));
+        if (map)
+        {
+            while (chunks--)
+            {
+                if (mincore(reinterpret_cast<void *> (first),
+                            (size_t) GU_AMU_CHUNK * GU_PAGE_SIZE, map) == 0)
+                {
+                    for (size_t i = 0; i < GU_AMU_CHUNK; i++)
+                    {
+                        if (map[i])
+                        {
+                            size += GU_PAGE_SIZE;
+                        }
+                    }
+                }
+                else
+                {
+                    log_fatal << "Unable to get in-core state vector "
+                                 "for page range. Aborting.";
+                    abort();
+                }
+                first += (size_t) GU_AMU_CHUNK * GU_PAGE_SIZE;
+            }
+            pages &= GU_AMU_CHUNK - 1;
+            if (mincore(reinterpret_cast<void *> (first),
+                        pages * GU_PAGE_SIZE, map) == 0)
+            {
+                for (size_t i = 0; i < pages; i++)
+                {
+                    if (map[i]) size += GU_PAGE_SIZE;
+                }
+            }
+            else
+            {
+                log_fatal << "Unable to get in-core state vector "
+                             "for page range. Aborting.";
+                abort();
+            }
+            free(map);
+        }
+        else
+        {
+            log_fatal << "Unable to allocate memory for in-core state vector. "
+                      << "Aborting.";
+            abort();
+        }
+    }
+    return size;
+}
+
+#else
+
+/*
+ * In case of absence mincore syscall we simply return the total size
+ * of memory-mapped region:
+ */
+size_t gu_actual_memory_usage (const void * const ptr, const size_t length)
+{
+    return length;
+}
+
+#endif

--- a/galerautils/src/gu_mmap.hpp
+++ b/galerautils/src/gu_mmap.hpp
@@ -39,4 +39,7 @@ private:
 
 } /* namespace gu */
 
+/** Returns actual memory usage by allocated page range: **/
+size_t gu_actual_memory_usage (const void * const ptr, const size_t length);
+
 #endif /* __GCACHE_MMAP__ */

--- a/gcache/src/GCache.cpp
+++ b/gcache/src/GCache.cpp
@@ -74,6 +74,14 @@ namespace gcache
                   << "\n" << "GCache frees   : " << frees;
     }
 
+    size_t GCache::actual_pool_size ()
+    {
+        gu::Lock lock(mtx);
+        return mem.actual_pool_size() +
+               rb.actual_pool_size(&mtx) +
+               ps.actual_pool_size(&mtx);
+    }
+
     size_t GCache::allocated_pool_size ()
     {
         gu::Lock lock(mtx);

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -104,6 +104,11 @@ namespace gcache
          */
         size_t allocated_pool_size ();
 
+        /*!
+         * Returns actual gcache memory pool size (in bytes).
+         */
+        size_t actual_pool_size ();
+
         class Buffer
         {
         public:

--- a/gcache/src/gcache_mem_store.cpp
+++ b/gcache/src/gcache_mem_store.cpp
@@ -75,6 +75,11 @@ MemStore::seqno_reset()
     }
 }
 
+size_t MemStore::actual_pool_size ()
+{
+  return size_;
+}
+
 size_t MemStore::allocated_pool_size ()
 {
   return size_;

--- a/gcache/src/gcache_mem_store.hpp
+++ b/gcache/src/gcache_mem_store.hpp
@@ -139,6 +139,7 @@ namespace gcache
         size_t _allocd () const { return size_; }
 
         size_t allocated_pool_size ();
+        size_t actual_pool_size ();
 
     private:
 

--- a/gcache/src/gcache_page.cpp
+++ b/gcache/src/gcache_page.cpp
@@ -169,6 +169,17 @@ gcache::Page::realloc (void* ptr, size_type size)
     }
 }
 
+size_t gcache::Page::actual_pool_size (gu::Mutex * mtx)
+{
+    void*  ptr= reinterpret_cast<void *> (mmap_.ptr);
+    size_t used= mmap_.size - min_space_;
+    size_t size;
+    mtx->unlock();
+    size = gu_actual_memory_usage(ptr, used);
+    mtx->lock();
+    return size;
+}
+
 size_t gcache::Page::allocated_pool_size ()
 {
     return mmap_.size - min_space_;

--- a/gcache/src/gcache_page.hpp
+++ b/gcache/src/gcache_page.hpp
@@ -10,8 +10,9 @@
 #include "gcache_memops.hpp"
 #include "gcache_bh.hpp"
 
-#include "gu_fdesc.hpp"
-#include "gu_mmap.hpp"
+#include <gu_fdesc.hpp>
+#include <gu_mmap.hpp>
+#include <gu_lock.hpp>
 
 #include <string>
 
@@ -54,6 +55,7 @@ namespace gcache
         void* parent() const { return ps_; }
 
         size_t allocated_pool_size ();
+        size_t actual_pool_size (gu::Mutex * mtx);
 
     private:
 

--- a/gcache/src/gcache_page_store.hpp
+++ b/gcache/src/gcache_page_store.hpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <deque>
 
+#include <gu_lock.hpp>
+
 namespace gcache
 {
     class PageStore : public MemOps
@@ -54,6 +56,7 @@ namespace gcache
         void  set_keep_count (size_t count) { keep_page_ = count; cleanup();}
 
         size_t allocated_pool_size ();
+        size_t actual_pool_size (gu::Mutex * mtx);
 
         /* for unit tests */
         size_t count()       const { return count_;        }
@@ -62,6 +65,7 @@ namespace gcache
 
     private:
 
+        gu::Mutex         mtx_;
         std::string const base_name_; /* /.../.../gcache.page. */
         size_t            keep_size_; /* how much pages to keep after freeing*/
         size_t            page_size_; /* min size of the individual page */

--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -499,6 +499,17 @@ namespace gcache
         assert_sizes();
     }
 
+    size_t RingBuffer::actual_pool_size (gu::Mutex * mtx)
+    {
+       void*  ptr= reinterpret_cast<void *> (mmap_.ptr);
+       size_t used= max_used_;
+       size_t size;
+       mtx->unlock();
+       size = gu_actual_memory_usage(ptr, used);
+       mtx->lock();
+       return size;
+    }
+
     size_t RingBuffer::allocated_pool_size ()
     {
        return max_used_;

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -12,6 +12,7 @@
 
 #include <gu_fdesc.hpp>
 #include <gu_mmap.hpp>
+#include <gu_lock.hpp>
 
 #include <string>
 #include <map>
@@ -102,6 +103,7 @@ namespace gcache
         }
 
         size_t allocated_pool_size ();
+        size_t actual_pool_size (gu::Mutex * mtx);
 
     private:
 


### PR DESCRIPTION
…ing mincore syscall

  Write sets are cached on node using GCache.

  GCache mechanism mmaps the file that it uses for storing write-set.
  Rough estimate of GCache size is available through variable "wsrep_gcache_pool_size"

  To get more accurate estimate (that exactly counts used mmap pages)
  is done using a mincore syscalls. This stat is now made available
  on system that supports mincore using new I_S.WSREP_STATS table.
