### PR TITLE
- PXC#469: CTAS incompatibility and failures

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -587,7 +587,15 @@ galera::Certification::do_test_v3(TrxHandle* trx, bool store_keys)
     long const      key_count(key_set.count());
     long            processed(0);
 
-    assert(key_count > 0);
+    // This check if the keys are appended.
+    // Generally almost all cases keys are appeneded before certification
+    // except in case of CTAS which is executed non-TOI fashion due to
+    // involvement of SELECT. If the source table is empty then no key
+    // is appended and so key_count == 0.
+    // Unfortunately there is no way to check if the original SQL statement
+    // is of type CTAS type but leaving this assert can cause random failure
+    // so we will disable it for now.
+    // assert(key_count > 0);
 
     key_set.rewind();
 


### PR DESCRIPTION
  CTAS (CREATE TABLE ... AS SELECT) is executed in normal form
  (not as TOI statement like other CREATE due to involvement of SELECT)

  This effectively causes issue when source table is empty which
  in turns skip appending of keys and eventually result in a debug
  mode assert during certification.

  Debug mode assert is good but failed to consider all possible cases.
  Forcing a fake key for making assert happy is wrong idea so we commented
  the assert which anyway is debug mode assert and not so fatal.
  Alternative would be to suppress assert only if command = CTAS
  but galera-plugin doesn't have access to such command.
  (unless we make interface changes).
