### PR TITLE
- PXC#419: Build galera without omitting frame pointer

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -69,7 +69,7 @@ Commandline Options:
 build_target = 'all'
 
 # Optimization level
-opt_flags    = ' -g -O3 -DNDEBUG'
+opt_flags    = ' -g -O3 -fno-omit-frame-pointer -DNDEBUG'
 
 # Architecture (defaults to build host type)
 compile_arch = ''
@@ -97,7 +97,7 @@ if debug_lvl >= 0 and debug_lvl < 3:
     opt_flags = ' -g -O%d -fno-inline' % debug_lvl
     dbug = True
 elif debug_lvl == 3:
-    opt_flags = ' -g -O3'
+    opt_flags = ' -g -O3 -fno-omit-frame-pointer'
 
 if dbug:
     opt_flags = opt_flags + ' -DGU_DBUG_ON'


### PR DESCRIPTION
  Build galera no-omit-frame-pointer to improve the backtrace
  for easy debugging. This is enabled with O3 optimization.

  This should have neglible performance difference especially
  on x86_64 architecture that has 16 register.
