### PR TITLE
- PXC#456: WSREP: FSM: no such a transition ROLLED_BACK -> ROLLED_BAC…

### DIFF
--- a/galera/src/wsdb.cpp
+++ b/galera/src/wsdb.cpp
@@ -32,11 +32,12 @@ void galera::Wsdb::print(std::ostream& os) const
 
 galera::Wsdb::Wsdb()
     :
-    trx_pool_  (TrxHandle::LOCAL_STORAGE_SIZE, 512, "LocalTrxHandle"),
-    trx_map_   (),
-    trx_mutex_ (),
-    conn_map_  (),
-    conn_mutex_()
+    trx_pool_    (TrxHandle::LOCAL_STORAGE_SIZE, 512, "LocalTrxHandle"),
+    trx_map_     (),
+    conn_trx_map_(),
+    trx_mutex_   (),
+    conn_map_    (),
+    conn_mutex_  ()
 {}
 
 
@@ -52,6 +53,9 @@ galera::Wsdb::~Wsdb()
     std::cerr << *this;
 #else
     for_each(trx_map_.begin(), trx_map_.end(), Unref2nd<TrxMap::value_type>());
+    for_each(conn_trx_map_.begin(),
+             conn_trx_map_.end(),
+             Unref2nd<ConnTrxMap::value_type>());
 #endif // !NDEBUG
 }
 
@@ -61,9 +65,25 @@ galera::Wsdb::find_trx(wsrep_trx_id_t const trx_id)
 {
     gu::Lock lock(trx_mutex_);
 
-    TrxMap::iterator const i(trx_map_.find(trx_id));
+    galera::TrxHandle* trx;
 
-    return (trx_map_.end() == i ? 0 : i->second);
+    if (trx_id != wsrep_trx_id_t(-1))
+    {
+        /* trx_id is valid and valid ids are unique.
+        Search for valid trx_id in trx_id -> trx map. */
+        TrxMap::iterator const i(trx_map_.find(trx_id));
+        trx = (trx_map_.end() == i ? NULL : i->second);
+    }
+    else
+    {
+        /* trx_id is default so search for repsective connection id
+        in connection-transaction map. */
+        pthread_t const id = pthread_self();
+        ConnTrxMap::iterator const i(conn_trx_map_.find(id));
+        trx = (conn_trx_map_.end() == i ? NULL : i->second);
+    }
+
+    return (trx);
 }
 
 
@@ -76,12 +96,27 @@ galera::Wsdb::create_trx(const TrxHandle::Params& params,
 
     gu::Lock lock(trx_mutex_);
 
-    std::pair<TrxMap::iterator, bool> i
-        (trx_map_.insert(std::make_pair(trx_id, trx)));
+    galera::TrxHandle* trx_ref;
+    if (trx_id != wsrep_trx_id_t(-1))
+    {
+        /* trx_id is valid add it to trx-map as valid trx_id is unique
+        accross connections. */
+        std::pair<TrxMap::iterator, bool> i
+            (trx_map_.insert(std::make_pair(trx_id, trx)));
+        if (gu_unlikely(i.second == false)) gu_throw_fatal;
+        trx_ref = i.first->second;
+    }
+    else
+    {
+        /* trx_id is default so add trx object to connection map
+        that is maintained based on pthread_id (alias for connection_id). */
+         std::pair<ConnTrxMap::iterator, bool> i
+             (conn_trx_map_.insert(std::make_pair(pthread_self(), trx)));
+        if (gu_unlikely(i.second == false)) gu_throw_fatal;
+        trx_ref = i.first->second;
+    }
 
-    if (gu_unlikely(i.second == false)) gu_throw_fatal;
-
-    return i.first->second;
+    return (trx_ref);
 }
 
 
@@ -151,11 +186,24 @@ galera::Wsdb::get_conn_query(const TrxHandle::Params& params,
 void galera::Wsdb::discard_trx(wsrep_trx_id_t trx_id)
 {
     gu::Lock lock(trx_mutex_);
-    TrxMap::iterator i;
-    if ((i = trx_map_.find(trx_id)) != trx_map_.end())
+    if (trx_id != wsrep_trx_id_t(-1))
     {
-        i->second->unref();
-        trx_map_.erase(i);
+        TrxMap::iterator i;
+        if ((i = trx_map_.find(trx_id)) != trx_map_.end())
+        {
+            i->second->unref();
+            trx_map_.erase(i);
+        }
+    }
+    else
+    {
+        ConnTrxMap::iterator i;
+        pthread_t id = pthread_self();
+        if ((i = conn_trx_map_.find(id)) != conn_trx_map_.end())
+        {
+            i->second->unref();
+            conn_trx_map_.erase(i);
+        }
     }
 }
 


### PR DESCRIPTION
…K with

  LOAD DATA INFILE

  Issue:

---

  LDI for that matter DML statement can fail due to multiple reasons.
  Some probable reasons are:
- Creating table w/o pk and setting wsrep_certify_nonPK = off
- Existing bug that causes partitioned table LDI to fail.
  ....etc.
  
  Statement failure will skip append_key which besides appending key also
  set valid trx_id.
  Such failed statements are rolled back with trx_id = default.
  Galera-Plugin try to check if there is an existing Trx Object with
  given trx_id before creating a new one.
  
  If there are 2 independent connections (connected to same cluster node)
  and both of these connections execute a failing statement then
  both of them will try to rollback with trx_id = default.
  
  Logic that cached trx_id to trx-object never considered this situation
  and one of the such connection will get reference to a object that belongs
  to other connection which is logically wrong as both connection are unrelated.
  This also causes operational in-consistency as latter connection accesses
  state already modified by former connection.
  (Causing the famous ROLLBACK -> ROLLBACK assert).
  ## Solution(s):
  
  (I am listing all possible solution with one we have selected)
- trx-map should use pair of <trx_id, conn_id> as map key.
- trx-map should use multi-map with trx_id -> TrxObject
  TrxObject can use valid conn_id (vs -1 for now).
  For valid trx_id there only 1 trx_id -> TrxObject pair
  for default there could be multiple trx_id -> TrxObjects pair
  so proper pair is selected based on conn_id.
  
  [Both of the above approach needs interface change so ruled out for now]
- Re-arrange the logic to discard_trx object while holding lock on trx
  so that latter connection will get reference to the object but will
  not be able to operate on it till former one is done.
  (Logically 2 connections are sharing the objects which itself is wrong
   but if this can be made possible with some tweak in the code it will
   introduce flow control as it involves exception handling).
- Introduce a separate map that will cache pthread_id -> TrxObject if
  trx_id = default.
  (Given the limited changes involved we opted for this solution though
  we would love to sort this out with upstream using interface change
  solutions mentioned above).
