### PR TITLE
PXC434 PXC-436 Crash in galera at certification

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1839,9 +1839,11 @@ wsrep_status_t galera::ReplicatorSMM::cert(TrxHandle* trx)
             if (gu_unlikely(trx->is_toi() && applicable)) // small sanity check
             {
                 // may happen on configuration change
-                log_warn << "Certification failed for TO isolated action: "
-                         << *trx;
-                assert(0);
+                log_fatal << "Certification failed for TO isolated action: "
+                          << *trx;
+                st_.mark_unsafe();
+                local_monitor_.leave(lo);
+                abort();
             }
             local_cert_failures_ += trx->is_local();
             trx->set_state(TrxHandle::S_MUST_ABORT);

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1838,13 +1838,19 @@ wsrep_status_t galera::ReplicatorSMM::cert(TrxHandle* trx)
         case Certification::TEST_FAILED:
             if (gu_unlikely(trx->is_toi() && applicable)) // small sanity check
             {
-                // In some rare scenarios, such as PXC-436, sequence
+                // In some rare scenarios (e.g., when we have multiple
+                // transactions awaiting certification, and the last
+                // node remaining in the cluster becomes PRIMARY due
+                // to the failure of the previous primary node and
+                // the assign_initial_position() was called), sequence
                 // number mismatch occurs on configuration change and
                 // then certification was failed. We cannot move server
-                // forward (when local_seqno > group_seqno) to avoid
-                // potential data loss, and hence will have to shut it
-                // down. Before shutting it down,we need to mark state
-                // as unsafe – to trigger SST at next server restart:
+                // forward (with last_seen_seqno < initial_position,
+                // see galera::Certification::do_test() for details)
+                // to avoid potential data loss, and hence will have
+                // to shut it down. Before shutting it down, we need
+                // to mark state as unsafe – to trigger SST at next
+                // server restart:
                 log_fatal << "Certification failed for TO isolated action: "
                           << *trx;
                 st_.mark_unsafe();

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -31,7 +31,7 @@ ReplicatorSMM::state_transfer_required(const wsrep_view_info_t& view_info)
                 {
                     // Local state sequence number is greater than group
                     // sequence number: states diverged on SST. We cannot
-                    // move server forward (when local_seqno > group_seqno)
+                    // move server forward (with local_seqno > group_seqno)
                     // to avoid potential data loss, and hence will have
                     // to shut it down. User must to remove state file and
                     // then restart server, if he/she wish to continue:

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -29,6 +29,12 @@ ReplicatorSMM::state_transfer_required(const wsrep_view_info_t& view_info)
             {
                 if (local_seqno > group_seqno)
                 {
+                    // Local state sequence number is greater than group
+                    // sequence number: states diverged on SST. We cannot
+                    // move server forward (when local_seqno > group_seqno)
+                    // to avoid potential data loss, and hence will have
+                    // to shut it down. User must to remove state file and
+                    // then restart server, if he/she wish to continue:
                     log_fatal
                         << "Local state seqno (" << local_seqno
                         << ") is greater than group seqno (" <<group_seqno

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -29,13 +29,13 @@ ReplicatorSMM::state_transfer_required(const wsrep_view_info_t& view_info)
             {
                 if (local_seqno > group_seqno)
                 {
-                    close();
-                    gu_throw_fatal
+                    log_fatal
                         << "Local state seqno (" << local_seqno
                         << ") is greater than group seqno (" <<group_seqno
                         << "): states diverged. Aborting to avoid potential "
                         << "data loss. Remove '" << state_file_
                         << "' file and restart if you wish to continue.";
+                    abort();
                 }
 
                 return (local_seqno != group_seqno);


### PR DESCRIPTION
In some rare scenarios (e.g., when we have multiple transactions awaiting certification, and the last node remaining in the cluster becomes PRIMARY due to the failure of the previous primary node and the assign_initial_position() was called) sequence number mismatch occurs on configuration change and then certification was failed. In some other rare scenarios, states diverged on SST and we see the local state sequence number is greater than group sequence number. In both cases we cannot move server forward to avoid potential data loss, and hence will have to shut it down. This patch eliminates the server crash because of the assert(0) or falling into exception handler (in the above scenarios).
