### PR TITLE
- PXC#436: Crash in galera at certification

### DIFF
--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -29,6 +29,12 @@ ReplicatorSMM::state_transfer_required(const wsrep_view_info_t& view_info)
             {
                 if (local_seqno > group_seqno)
                 {
+                    // Local state sequence number is greater than group
+                    // sequence number: states diverged on SST. We cannot
+                    // move server forward (with local_seqno > group_seqno)
+                    // to avoid potential data loss, and hence will have
+                    // to shut it down. User must to remove state file and
+                    // then restart server, if he/she wish to continue:
                     close();
                     gu_throw_fatal
                         << "Local state seqno (" << local_seqno
@@ -36,6 +42,7 @@ ReplicatorSMM::state_transfer_required(const wsrep_view_info_t& view_info)
                         << "): states diverged. Aborting to avoid potential "
                         << "data loss. Remove '" << state_file_
                         << "' file and restart if you wish to continue.";
+                    abort();
                 }
 
                 return (local_seqno != group_seqno);


### PR DESCRIPTION
  In some rare scenarios (e.g., when we have multiple transactions awaiting
  certification, and the last node remaining in the cluster becomes PRIMARY
  due to the failure of the previous primary node and the
  assign_initial_position() was called) sequence number mismatch occurs on
  configuration change and then certification was failed.
  In some other rare scenarios, states diverged on SST and we see the local
  state sequence number is greater than group sequence number.
  In both cases we cannot move server forward to avoid potential data loss,
  and hence will have to shut it down. This patch eliminates the server crash
  because of the assert(0) or falling into exception handler
  (in the above scenarios).
