### PR TITLE
- #PXC-269: Cluster node stuck in Donor/Desync state after hard recovery

### DIFF
--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -964,8 +964,8 @@ gcs_handle_act_state_req (gcs_conn_t*          conn,
 
 /*! Allocates buffer with malloc to pass to the upper layer. */
 static long
-gcs_handle_state_change (gcs_conn_t*           conn,
-                         const struct gcs_act* act)
+gcs_handle_state_change (gcs_conn_t*     conn,
+                         struct gcs_act* act)
 {
     gu_debug ("Got '%s' dated %lld", gcs_act_type_to_str (act->type),
               gcs_seqno_gtoh(*(gcs_seqno_t*)act->buf));
@@ -975,7 +975,7 @@ gcs_handle_state_change (gcs_conn_t*           conn,
     if (buf) {
         memcpy (buf, act->buf, act->buf_len);
         /* initially act->buf points to internal static recv buffer. No leak here */
-        ((struct gcs_act*)act)->buf = buf;
+        act->buf = buf;
         return 1;
     }
     else {


### PR DESCRIPTION
In very rare scenarios the server "hangs" in the Donor/Desync state despite the fact that the state transfer request (SST) was aborted or completed successfully. At the same time there are clear signs of de-synchronization (the different views on the current state) between the GCS and Replicator in the Galera. A more detailed analysis shows that the notification about completion of the SST is not reached mysqld (notification callback was not called from wsrep provider).

Jenkins build: http://jenkins.percona.com/job/pxc56.clone.galera3/2319/
