### PR TITLE
- #PXC-484: garbd requires port number in sysconfig

### DIFF
--- a/gcomm/src/gmcast.cpp
+++ b/gcomm/src/gmcast.cpp
@@ -243,6 +243,10 @@ void gcomm::GMCast::set_initial_addr(const gu::URI& uri)
             {
                 port = Defaults::GMCastTcpPort;
             }
+            catch (gu::NotSet&)
+            {
+                port = Defaults::GMCastTcpPort;
+            }
         }
 
         std::string initial_uri = uri_string(get_scheme(use_ssl_), host, port);


### PR DESCRIPTION
Comments in /etc/sysconfig/garb indicates that adding port is optional:
# A comma-separated list of node addresses (address[:port]) in the cluster

And yet, if you won't add the port, garb fails to start. For example:
GALERA_NODES="10.121.215.31,10.121.215.32"
If you add port, service starts normally:
GALERA_NODES="10.121.215.31:4567,10.121.215.32:4567"
This happens because exclusion gu::NotSet forgotten and unhandled in the gmcast.cpp file.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone.galera3/2322/
