### PR TITLE
- PXC #384: Garb init script causes new UUIDs to be generated every time

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -13,6 +13,7 @@
 
 #define COMMON_BASE_DIR_KEY      "base_dir"
 #define COMMON_BASE_DIR_DEFAULT  "."
+#define COMMON_BASE_DIR_DAEMON   "/var/lib/galera"
 
 #define COMMON_STATE_FILE "grastate.dat"
 #define COMMON_VIEW_STAT_FILE "gvwstate.dat"


### PR DESCRIPTION
This error occurs when the configuration file is not specifies base directory (there is no base_dir option) AND garbd do not have write access to the current directory. For example, if it is running as a daemon, the current directory can be / and garbd unable to write the ./gvwstate.dat file. After this patch, garbd makes some tests:
- whether the current directory is root (/) or not?
- whether we have write access to the default directory (./) or not?
  If the current directory is root or we do not have write access to the current (default) directory, then patch thinks that we are working as a daemon.
  Then it tries to use the /var/lib/galera/ path to store gvwstate.dat [G in a similar way, as so many other linux demons do. If the /var/lib/galera directory does not exist, garbd trying to create it. If it is impossible, garbd signals a fatal error.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone.galera3/2324/
