### PR TITLE
- PXC#493: Two garbd instances cannot connect to single node in cluster

### DIFF
--- a/gcomm/src/conf.cpp
+++ b/gcomm/src/conf.cpp
@@ -118,6 +118,7 @@ gcomm::Conf::register_params(gu::Config& cnf)
 
     GCOMM_CONF_ADD (COMMON_BASE_HOST_KEY);
     GCOMM_CONF_ADD (COMMON_BASE_PORT_KEY);
+    GCOMM_CONF_ADD (COMMON_BASE_DIR_KEY);
 
     GCOMM_CONF_ADD_DEFAULT(ProtonetBackend);
     GCOMM_CONF_ADD_DEFAULT(ProtonetVersion);


### PR DESCRIPTION
  (CID#63971)

  Issue:

---
- garbd uses default base_dir as current working directory.
  It creates gvwstate.dat (state file) in this CWD.
- If 2 instances of garbd are started from same directory 2nd instance
  will remove the existing file and try to re-create new one.
  This process will messup even the 1st garbd instance and of-course
  it will not allow 2nd instance to bootup.
- garbd has an option to specific working directory using base_dir
  option but unfortunately due to bug in code this option was not
  registered in list of options to parse leading to an error.
  ## Solution:
- Code fixes the issue by adding the option to vector of
  recognizable options.
  
  Workaround till then is simply start garbd instances from different
  directories.
