### PR TITLE
This is patch for the https://bugs.launchpad.net/percona-xtradb-clust…

### DIFF
--- a/debian/galera-arbitrator-3.preinst
+++ b/debian/galera-arbitrator-3.preinst
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#DEBHELPER#
+
+set -e
+
+if [ ! -d "/var/lib/galera" ]; then
+
+mkdir -p /var/lib/galera
+
+if id -u nobody > /dev/null 2>&1; then
+    chown nobody:nogroup /var/lib/galera
+fi
+
+fi

--- a/packages/debian/percona-xtradb-cluster-garbd-3.x.preinst
+++ b/packages/debian/percona-xtradb-cluster-garbd-3.x.preinst
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#DEBHELPER#
+
+set -e
+
+if [ ! -d "/var/lib/galera" ]; then
+
+mkdir -p /var/lib/galera
+
+if id -u nobody > /dev/null 2>&1; then
+    chown nobody:nogroup /var/lib/galera
+fi
+
+fi

--- a/packages/rpm/percona-xtradb-cluster-galera.spec
+++ b/packages/rpm/percona-xtradb-cluster-galera.spec
@@ -132,6 +132,7 @@ install -m 644 $RPM_BUILD_DIR/%{src_dir}/garb/files/garb.cnf \
     $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/garb
 install -d "$RPM_BUILD_ROOT/%{_bindir}"
 install -d "$RPM_BUILD_ROOT/%{_libdir}"
+install -d "$RPM_BUILD_ROOT/%{_sharedstatedir}/galera"
 
 %if 0%{?systemd}
 install -D -m 644 $RPM_BUILD_DIR/%{src_dir}/garb/files/garb.service \
@@ -179,6 +180,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
+%attr(0755,nobody,nobody) %dir %{_sharedstatedir}/galera
 # This is a symlink
 %attr(0755,root,root) %{_libdir}/libgalera_smm.so
 %attr(0755,root,root) %{_libdir}/galera3/libgalera_smm.so
@@ -190,10 +192,10 @@ rm -rf $RPM_BUILD_ROOT
 %doc %attr(0644,root,root) %{docs}/LICENSE.crc32c
 %doc %attr(0644,root,root) %{docs}/LICENSE.chromium
 
-
 %files -n Percona-XtraDB-Cluster-garbd-3
 %defattr(-,root,root,-)
 %config(noreplace,missingok) %{_sysconfdir}/sysconfig/garb
+%attr(0755,nobody,nobody) %dir %{_sharedstatedir}/galera
 %if 0%{?systemd}
     %attr(0644, root, root) %{_unitdir}/garb.service
     %attr(0755,root,root) %{_bindir}/garb-systemd

--- a/scripts/mysql/build.sh
+++ b/scripts/mysql/build.sh
@@ -634,6 +634,8 @@ if [ $TAR == "yes" ]; then
     install -m 755 -d $GALERA_BINS
     install -m 755 -d $GALERA_LIBS
 
+    install -m 755 -d $GALERA_DIST_DIR/var/lib/galera
+
     if [ "$SCONS" == "yes" ]
     then
         SCONS_VD=$GALERA_SRC

--- a/scripts/packages/freebsd.sh
+++ b/scripts/packages/freebsd.sh
@@ -18,6 +18,9 @@ rm -rf "$PBR"
 mkdir -p "$PBR"
 
 install -d "$PBR/"{bin,lib/galera,share/doc/galera,etc/rc.d,libdata/ldconfig}
+
+install -m 755 -d "$PBR/"{var/lib/galera}
+
 install -m 555 "$PBD/garb/files/freebsd/garb.sh"      "$PBR/etc/rc.d/garb"
 install -m 555 "$PBD/garb/garbd"                      "$PBR/bin/garbd"
 install -m 444 "$PBD/libgalera_smm.so"                "$PBR/lib/galera/libgalera_smm.so"

--- a/scripts/packages/freebsd/galera-mtree
+++ b/scripts/packages/freebsd/galera-mtree
@@ -953,4 +953,11 @@
     ..
     www
     ..
+    var
+        lib
+/set type=dir uname=nobody gname=nobody mode=0755
+            galera
+            ..
+        ..
+    ..
 ..

--- a/scripts/packages/galera-obs.spec
+++ b/scripts/packages/galera-obs.spec
@@ -201,6 +201,8 @@ install -m 755 $RBD/garb/garbd                    $RBR%{_bindir}/garbd
 install -d $RBR%{libs}
 install -m 755 $RBD/libgalera_smm.so              $RBR%{libs}/libgalera_smm.so
 
+install -d "$RPM_BUILD_ROOT/%{_sharedstatedir}/galera"
+
 install -d $RBR%{docs}
 install -m 644 $RBD/COPYING                       $RBR%{docs}/COPYING
 install -m 644 $RBD/asio/LICENSE_1_0.txt          $RBR%{docs}/LICENSE.asio
@@ -308,6 +310,8 @@ fi
 
 %attr(0755,root,root) %dir %{libs}
 %attr(0755,root,root) %{libs}/libgalera_smm.so
+
+%attr(0755,nobody,nobody) %dir %{_sharedstatedir}/galera
 
 %attr(0755,root,root) %dir %{docs}
 %doc %attr(0644,root,root) %{docs}/COPYING

--- a/scripts/packages/galera.list
+++ b/scripts/packages/galera.list
@@ -15,6 +15,8 @@ f 755 root root $INIT_DEST/garb  $BUILD_BASE/garb/files/garb.sh
 d 755 root root $BINS_DEST -
 f 755 root root $BINS_DEST/garbd $BUILD_BASE/garb/garbd
 
+d 755 nobody nobody /var/lib/galera -
+
 d 755 root root $LIBS_DEST -
 f 755 root root $LIBS_DEST/libgalera_smm.so $BUILD_BASE/libgalera_smm.so
 


### PR DESCRIPTION
…er/+bug/1532857 issue.

In the past, we are faced with the problem that the Galera’s cluster arbitrator daemon (garbd) does not keep uuid when the user restart it (https://jira.percona.com/browse/PXC-384).

This error occurs when the configuration file does not specified base directory and arbitrator daemon does not have write access to the current directory (because default base directory = "./"). For example, if it is running as a daemon under "nobody" user, the current directory can be "/" and garbd is unable to write state file (without root privileges). Therefore, after restart, it cannot read the uuid from a nonexistent state file.

After PXC-384 patch, garbd daemon makes some tests and if the current directory is global root ("/"), unreachable or garbd does not have write access to the default directory ("./"), then garbd thinks that it launched as a daemon. Then it tries to use the "/var/lib/galera/" path to store state file – in a similar way, as so many other linux demons do. If the "/var/lib/galera" directory does not exist, the garbd trying to create it. If it is impossible, then garbd is signaling a fatal error.

However, because the PXC installer does not create this directory yourself, we have a problem.

On the other hand, without the PXC-384 patch, we would have improperly working garbd, which is unable to read own state after a restart.

Therefore, we need to create a "/var/lib/galera" directory in the installer, and assign it to "nobody" user.

This patch adds this directory.
