### PR TITLE
- #PXC-473: Error during cluster start shouldn't immediately zero-out grastate

### DIFF
--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -471,7 +471,7 @@ namespace galera
                                              const wsrep_uuid_t& group_uuid,
                                              wsrep_seqno_t       group_seqno);
 
-        void send_state_request (const StateRequest* req);
+        long send_state_request (const StateRequest* req, const bool unsafe);
 
         void request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,


### PR DESCRIPTION
This patch contains three fixes, as they partially affect the same lines of code. All three are associated with the processing of errors during SST/IST, immediately after or before SST/IST. Two of them are described as PXC-473 and PXC-329, the third error is most evident after correcting the previous two, but it has been repeatedly observed as a side effect of other errors - its symptom is hanging of the thread that waits for completion of the SST, which occurs when changing state with S_JOINING any other.
# PART ONE (PXC-473)

In many cases, grastate.dat zeroed if we encounter an error at the node startup. For example, grastate.dat zeroed on misconfiguration in the my.cnf. As a result, we have to perform a full SST after the node restart, although we could only do IST.

This is because the function ReplicatorSMM::request_state_transfer() always marks the state as "unsafe" fearing that current state will be broken in the process of execution of the SST. Since one general function is responsible for the SST and IST, it happens even when the SST is not required or when the SST is trivial.

We must mark the state as the "unsafe" before SST because the current state may be changed during execution of the SST and it will no longer match the stored seqno (state becomes "unsafe" after the first modification of data during the SST, but unfortunately, we do not have callback or wsrep API to notify about the first data modification).

On the other hand, in cases where the full SST is not required and we want to use IST, we need to save the current state - to prevent unnecessary SST after node restart (if IST will be failed).

Therefore, to correct this error we need to check whether the full state transfer (SST) is required or not, before marking state as unsafe.
# PART TWO (PXC-329)

Even when node is evicted from the cluster in middle of SST, the SST may completes normally (and InnoDB starts). After this, the node calls the gcs_join function (from gcs/src/gcs.cpp) and tries to join the cluster. However, this is impossible, because the node is already evicted. Therefore, the _join() function (which called from gcs_join) fails. Then node does IST (which also fails), after/during which it is aborted.

To fix this, we should avoid joining the cluster through gcs_join if node is evicted. To do this, we should check the current connection state in the gcs_join() function to return from it immediately if the node's communication channel was closed.

And we should not do the IST when we left S_JOINING state (for example, if we have lost the connection to the network or we were evicted from the cluster).
# PART THREE

If SST is completed after the connection lost or when the state changed from the S_JOINING to some other, the ReplicatorSMM::request_state_transfer function hangs forever, because the associated ReplicatorSMM::sst_received function not calls the signal() for the sst_cond_ conditional variable. This is due to a premature return from the sst_received function in case of state change.

Ti fix this, we should to check the state only after we signalized about completion of the SST - otherwise the request_state_transfer() function will be infinitely wait on the sst_cond_ condition variable, for which no one will call the signal() function.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone.galera3.testgalera/4/ (Galera)

PXC PR & Jenkins builds here: https://github.com/percona/percona-xtradb-cluster/pull/95
