### PR TITLE
- #PXC-516: Unknown option causes cluster node to fail with assert in debug mode

### DIFF
--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -77,7 +77,10 @@ ReplicatorSMM::sst_received(const wsrep_gtid_t& state_id,
     // infinitely wait on the sst_cond_ condition variable, for which no one
     // will call the signal() function:
 
-    if (state_() == S_JOINING)
+    // S_CONNECTED also valid here if sst_received() called just after
+    // send_state_request(), when the state yet not shifted to S_JOINING:
+
+    if (state_() == S_JOINING || state_() == S_CONNECTED)
     {
         return WSREP_OK;
     }


### PR DESCRIPTION
Launching mysqld server with an unknown option triggers the assertion in the process of its termination. While it should shutdown with clean error message.

This is because analysis of the server options and transfer of the state (SST) are run simultaneously, but mysqld does not provide any way for emergency completion of the SST script (which running in separate process). When the server finds an unknown option, it calls unireg_abort() function that can detect incomplete thread and can trigger assertion in debug mode.

First, we have incomplete thread, which created in order to interact with the SST process. Second, until the SST process yet not terminated, we have an incomplete thread, which waits on the "sst_cond_" conditional variable in the Galera code. However, this variable will be set only at the end of SST process, in the sst_received() callback function. Therefore, if the SST is continued, this thread also freezes.

To solve these problems, I added code that emergency completes the SST process by sending a SIGTERM signal to it when unireg_abort() was called. This leads to completion of the thread, which interacts with the SST process. Also, sst_received() callback function will be called after termination of the SST process, and it unlocks the thread, which waiting on the "sst_cond_" conditional variable (in the Galera code).

Also, I corrected a race condition in the Galera code - calling of the sst_received() callback immediately after sending SST request should not be terminated with an error, even if we have not yet shifted to the S_JOINING state.

Related changes in the PXC code we can see here: https://github.com/percona/percona-xtradb-cluster/pull/113
