### PR TITLE
- #PXC-546:  Seqno in the grastate.dat file is reset to "-1" and remains undefined until completion of the SST or IST

### DIFF
--- a/galera/src/ist.hpp
+++ b/galera/src/ist.hpp
@@ -88,6 +88,7 @@ namespace galera
             int                   version_;
             bool                  use_ssl_;
             bool                  running_;
+            bool                  interrupted_;
             bool                  ready_;
         };
 

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -42,6 +42,7 @@ namespace galera
             SST_NONE,
             SST_WAIT,
             SST_REQ_FAILED,
+            SST_CANCELED,
             SST_FAILED
         } SstState;
 
@@ -207,7 +208,8 @@ namespace galera
         wsrep_status_t cert_and_catch(TrxHandle* trx);
         wsrep_status_t cert_for_aborted(TrxHandle* trx);
 
-        void update_state_uuid (const wsrep_uuid_t& u);
+        void update_state_uuid (const wsrep_uuid_t& u,
+                                const wsrep_seqno_t seqno);
         void update_incoming_list (const wsrep_view_info_t& v);
 
         /* aborts/exits the program in a clean way */
@@ -588,6 +590,7 @@ namespace galera
         ActionSource*        as_;
         GcsActionSource      gcs_as_;
         ist::Receiver        ist_receiver_;
+        bool                 ist_prepared_;
         ist::AsyncSenderMap  ist_senders_;
 
         // trx processing

--- a/galera/src/saved_state.cpp
+++ b/galera/src/saved_state.cpp
@@ -158,13 +158,17 @@ SavedState::set (const wsrep_uuid_t& u, wsrep_seqno_t s)
 
     if (corrupt_) return;
 
-    uuid_ = u;
-    seqno_ = s;
+    // Write new state if uuid or seqno was changed:
+    if (uuid_ != u || seqno_ != s)
+    {
+        uuid_ = u;
+        seqno_ = s;
 
-    if (0 == unsafe_())
-        write_and_flush (u, s);
-    else
-        log_debug << "Not writing state: unsafe counter is " << unsafe_();
+        if (0 == unsafe_())
+            write_and_flush (u, s);
+        else
+            log_debug << "Not writing state: unsafe counter is " << unsafe_();
+    }
 }
 
 /* the goal of unsafe_, written_uuid_, current_len_ below is


### PR DESCRIPTION
Seqno in the grastate.dat file is reset to "-1" (although the state is not marked as "unsafe") each time when the server is started (this done in Galera initialization, see the galera::ReplicatorSMM::update_state_uuid() function) and remains undefined until completion of the SST or IST.

To correct this error is sufficient to pass the current value of seqno into st_.set(...) function that is called from the galera::ReplicatorSMM::update_state_uuid(). Currently it called with the WSREP_SEQNO_UNDEFINED argument that causes this bug.

We also need to add a new logic into the recv_IST() function, to keep the state marked as having an undefined position after the start of the data changes during IST. To do this, if the current position is defined (for example, when there were no SST before IST), then we need to change it to an undefined position before applying the first transaction, since during the application of transactions (or after the IST) server may fail.

Related pull request for PXC is located here: https://github.com/percona/percona-xtradb-cluster/pull/114
