### PR TITLE
PXC-553 : Crash when setting fc_limit=20000 and then running stress

### DIFF
--- a/galerautils/src/gu_fifo.h
+++ b/galerautils/src/gu_fifo.h
@@ -51,6 +51,8 @@ extern void* gu_fifo_get_tail  (gu_fifo_t* q);
 extern void  gu_fifo_push_tail (gu_fifo_t* q);
 /*! Return how many items are in the queue (unprotected) */
 extern long  gu_fifo_length    (gu_fifo_t* q);
+/*! Returns the maximum number of items allowed in the queue (unprotected) */
+extern long  gu_fifo_max_length(gu_fifo_t* q);
 /*! Return how many items were in the queue on average per push_tail() */
 extern void  gu_fifo_stats_get (gu_fifo_t* q, int* q_len, int* q_len_max,
                                 int* q_len_min, double* q_len_avg);

--- a/galerautils/tests/gu_fifo_test.c
+++ b/galerautils/tests/gu_fifo_test.c
@@ -33,6 +33,8 @@ START_TEST (gu_fifo_test)
     fail_if (gu_fifo_length(fifo) != 0, "fifo->used is %lu for an empty FIFO",
              gu_fifo_length(fifo));
 
+    fail_if (gu_fifo_max_length(fifo) < FIFO_LENGTH);
+
     // fill FIFO
     for (i = 0; i < FIFO_LENGTH; i++) {
         item = gu_fifo_get_tail (fifo);
@@ -205,6 +207,77 @@ START_TEST(gu_fifo_cancel_test)
 }
 END_TEST
 
+/* Test the functionality when a row gets deleted if the head
+   reaches the end of a row (we have to ensure that the tail is
+   in the same row).
+*/
+START_TEST(gu_fifo_wrap_around_test)
+{
+    gu_fifo_t* fifo;
+    long i;
+    size_t* item;
+    long used;
+
+    #define FIFO_WRAP_LENGTH 2048
+
+    fifo = gu_fifo_create (FIFO_WRAP_LENGTH, sizeof(i));
+    fail_if (fifo == NULL);
+    fail_if (gu_fifo_length(fifo) != 0, "fifo->used is %lu for an empty FIFO",
+             gu_fifo_length(fifo));
+
+    /* fill FIFO */
+    for (i = 0; i < FIFO_WRAP_LENGTH; i++) {
+        item = gu_fifo_get_tail (fifo);
+        fail_if (item == NULL, "could not get item %ld", i);
+        *item = 0xCCCC;
+        gu_fifo_push_tail (fifo);
+    }
+
+    used = i;
+    fail_if (gu_fifo_length(fifo) != used, "used is %zu, expected %zu", 
+             used, gu_fifo_length(fifo));
+
+    /* run through the queue (ensure that we do gu_fifo_pop_head() at the
+     * end of a row) */
+    for (i = 0; i < FIFO_WRAP_LENGTH*2; i++) {
+        int err;
+        item = gu_fifo_get_head (fifo, &err);
+        fail_if (item == NULL, "could not get item %ld", i);
+        fail_if (*item != (ulong)0xCCCC, "got %ld, expected %lx", *item, 0xCCCC);
+        gu_fifo_pop_head (fifo);
+
+        item = gu_fifo_get_tail (fifo);
+        fail_if (item == NULL, "could not get item %ld", i);
+        *item = 0xCCCC;
+        gu_fifo_push_tail (fifo);
+    }
+
+    /* drain the queue */
+    used = gu_fifo_length(fifo);
+    for (i = 0; i < used; i++) {
+        int err;
+        item = gu_fifo_get_head (fifo, &err);
+        fail_if (item == NULL, "could not get item %ld", i);
+        fail_if (*item != (ulong)0xCCCC, "got %ld, expected %lx", *item, 0xCCCC);
+        gu_fifo_pop_head (fifo);
+    }
+
+    fail_if (gu_fifo_length(fifo) != 0,
+             "gu_fifo_length() for empty queue is %lx",
+             gu_fifo_length(fifo));
+
+    gu_fifo_close (fifo);
+
+    int err;
+    item = gu_fifo_get_head (fifo, &err);
+    fail_if (item != NULL);
+    fail_if (err  != -ENODATA);
+
+    gu_fifo_destroy (fifo);
+
+}
+END_TEST
+
 Suite *gu_fifo_suite(void)
 {
     Suite *s  = suite_create("Galera FIFO functions");
@@ -213,6 +286,7 @@ Suite *gu_fifo_suite(void)
     suite_add_tcase (s, tc);
     tcase_add_test  (tc, gu_fifo_test);
     tcase_add_test  (tc, gu_fifo_cancel_test);
+    tcase_add_test  (tc, gu_fifo_wrap_around_test);
     return s;
 }
 

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -750,6 +750,11 @@ _set_fc_limits (gcs_conn_t* conn)
     conn->upper_limit = conn->params.fc_base_limit * fn + .5;
     conn->lower_limit = conn->upper_limit * conn->params.fc_resume_factor + .5;
 
+    /* The upper/lower limits cannot exceed the number of items in the
+     * receive queue, so bound them by the max length. */
+    conn->upper_limit = std::min(conn->upper_limit, gu_fifo_max_length(conn->recv_q));
+    conn->lower_limit = std::min(conn->lower_limit, gu_fifo_max_length(conn->recv_q));
+
     gu_info ("Flow-control interval: [%ld, %ld]",
              conn->lower_limit, conn->upper_limit);
 }


### PR DESCRIPTION
Issue:
Set the fc_limit=20000, and then block the node ("flush tables with read lock").
The queue will eventually reach the limit (which is actually ~34800), but
before that it will reach the size of the receive queue (which is set upon
startup, and on a 256MB machine will hold 32K entries). If you then
"unlock tables", this will hit an assert in the code.

There is a bug in the fifo queue implementation that if the circular buffer
has wrapped (so that -->tail ... head-->) and that head and tail are in the
same memory block, when head reaches the end of the block,it will free()
the block, thus erasing part of the entries.

Solution:
(1) Fix the bug in the fifo queue so that the block is not prematurely released.
(2) Ensure that the limits resulting by setting fc_limit do not exceed the
    maximum size of the queue.
