### PR TITLE
- #PXC-501: galera_split_brain TC failing with following assertion intermittently

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -118,6 +118,17 @@ galera::Certification::purge_for_trx_v3(TrxHandle* trx)
     for (long i = 0; i < keys.count(); ++i)
     {
         const KeySet::KeyPart& kp(keys.next());
+
+        // The key in the incoming write set may be empty for
+        // locally created transaction. However, such key cannot
+        // be inserted in the certification index, therefore we
+        // can just skip it immediately:
+
+        if (kp.version() == KeySet::EMPTY)
+        {
+            continue;
+        }
+
         KeySet::Key::Prefix const p(kp.prefix());
 
         KeyEntryNG ke(kp);


### PR DESCRIPTION
galera_split_brain TC failing with assertion intermittently in the function KeyPart::matches (), which compares the two keys, because one of those keys is empty (the field "version" in this key contains the value "EMPTY").

The key to a locally created transaction may be empty until it is completed, but the current code does not allow this and trying looking for a key in the certification index. However, technically this key would fit to all the elements of the certification index. Therefore, the key comparison function in the KeyPart class has assertion to detect such incorrect comparisons, which leads to the PXC-501 error. However, the fact of the empty key cannot be inserted in the certification index; therefore, we can just skip it immediately.

Related PXC patch here: https://github.com/percona/percona-xtradb-cluster/pull/121
