### PR TITLE
- #PXC-426: Race condition during IST

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1470,9 +1470,30 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
         if (st_required && app_wants_st)
         {
             // GCache::Seqno_reset() happens here
-            request_state_transfer (recv_ctx,
-                                    group_uuid, group_seqno, app_req,
-                                    app_req_len);
+            long ret =
+                request_state_transfer (recv_ctx,
+                                        group_uuid, group_seqno, app_req,
+                                        app_req_len);
+
+            if (ret < 0 || sst_state_ == SST_CANCELED)
+            {
+                // If the request was canceled due to an error at
+                // the GCS level or if IST/SST request was canceled
+                // by another thread (by initiative of the server),
+                // and if the node remain in the S_JOINING state,
+                // then we must return it to the S_CONNECTED state.
+                // The S_CONNECTED is the original state, which
+                // exist before the request_state_transfer started.
+                // If state transfer failed then we move the node
+                // back to old state. S_CONNECTED state will help
+                // us restart SST, especially if mysqldump method
+                // will used for state transfer:
+
+                if (state_() == S_JOINING)
+                {
+                    state_.shift_to(S_CONNECTED);
+                }
+            }
         }
         else
         {
@@ -1513,8 +1534,13 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
             st_.set(state_uuid_, WSREP_SEQNO_UNDEFINED);
         }
 
-        if (state_() == S_JOINING && sst_state_ != SST_NONE
-                                  && sst_state_ != SST_CANCELED)
+        // We should not try to join the cluster at the GCS level,
+        // if the node not in the S_JOINING state, or if we did not
+        // make the IST/SST request or if it failed. In other words,
+        // any state (SST_NONE, SST_CANCELED) other than SST_WAIT
+        // not require us to sending JOIN message at the GCS level:
+
+        if (sst_state_ == SST_WAIT && state_() == S_JOINING)
         {
             /* There are two reasons we can be here:
              * 1) we just got state transfer in request_state_transfer() above;

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -475,7 +475,7 @@ namespace galera
 
         long send_state_request (const StateRequest* req, const bool unsafe);
 
-        void request_state_transfer (void* recv_ctx,
+        long request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,
                                      wsrep_seqno_t       group_seqno,
                                      const void*         sst_req,

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -728,6 +728,17 @@ gcs_group_handle_join_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
 
             if (from_donor && peer_idx == group->my_idx &&
                 GCS_NODE_STATE_JOINER == group->nodes[peer_idx].status) {
+
+                // If there is an error code ENODATA, it is indication
+                // that state of the joiner node was diverged too much
+                // and we need to move from IST to SST. We should not
+                // treat this as a fatal error:
+
+                if (seqno == -ENODATA)
+                {
+                    return 0;
+                }
+
                 // this node will be waiting for SST forever. If it has only
                 // one recv thread there is no (generic) way to wake it up.
                 gu_fatal ("Will never receive state. Need to abort.");
@@ -1137,15 +1148,23 @@ group_find_ist_donor (const gcs_group_t* const group,
         return -1;
     }
 
+    // The safety_gap is heuristically calculated difference
+    // to which the group seqno can be displaced in the process
+    // of sending a request for the IST. We should use the
+    // ist_seqno - safety_gap (instead of ist_seqno) during
+    // the search of the donor node, to avoid situations when
+    // seqno on the donor node has changed so much that IST
+    // is not possible (and we need to run SST):
+
     if (str_len) {
         // find ist donor by name.
         idx = group_find_ist_donor_by_name_in_string(
-            group, joiner_idx, str, str_len, ist_seqno, status);
+            group, joiner_idx, str, str_len, ist_seqno - safety_gap, status);
         if (idx >= 0) return idx;
     }
     // find ist donor by status.
     idx = group_find_ist_donor_by_state(
-        group, joiner_idx, ist_seqno, status);
+        group, joiner_idx, ist_seqno - safety_gap, status);
     if (idx >= 0) return idx;
     return -1;
 }


### PR DESCRIPTION
The node lost connectivity with other nodes in the cluster (for some time) due to network problems. Therefore, it needs to run IST to synchronize their state with cluster.

During node operation IST starts only when local_seqno < group_seqno while configuration change is detected in the cluster (first it detected at the GCS layer and then GCS_ACT_CONF message is received in the action source handler and processed in the Replicator).

This occurs after the cluster becomes non-primary status, and then returns to a state with primary component. Alternatively, when node has lost connectivity with the cluster (but this is recoverable condition) and after this, it re-joined the cluster.

However, if we already have large network delays and packet losses, then during IST we can encounter situation when seqno on the donor node has changed so much that IST is not possible and we need to run SST.

The immediate cause of the PXC-426 error is the inability of the PXC to run SST (using methods that different from mysqldump) on the working node. PXC and Galera written in such way that we need a full restart before launching new SST.

Therefore, we need to show the user a message that indicates that we need to perform SST after restart and to stop working. However, currently the server continues to work, even when the synchronization of the node is no longer possible and it cannot continue normal operation in a cluster.

However, why do we encountered situation when seqno had goes forward during IST?

The fact, that the heuristic algorithm of the donor selection, which implemented in the GCS, contains the flaw, because of what it might choose as a donor such node, where seqno can go ahead before the IST request will received.

Therefore, we need to improve the heuristics in the donor node selection algorithm (in the group_find_ist_donor function) to make this flaw less likely.

It is difficult to assess the situation from which we have only the server logs - but it is possible that the correction of the heuristic would not help us to eliminate all cases when situation like the PXC-426 can arise.

We can see in the logs that one of the donor nodes has performed SST and it has changed their seqno immediately before it received the IST request. This is the second possible reason for this error.

In this case, as I have said above, we need to tell the user that the IST is impossible and server restart is required. Because we cannot change PXC architecture quickly, without rewriting large fragments of its code.

Theoretically, a similar diagnostic and error also possible if the MySQL server does not prepared structures for the SST in the view callback (in the wsrep_view_handler_cb function) after restart of the node - when it returns only the structures for IST.

But in the current version of PXC this should not happen after node restart, because after restrart the wsrep_sst_prepare function (which called from wsrep_view_handler_cb) always returns a non-zero value as length of the SST request.

However, the assertion in the wsrep_view_handler_cb function only checks for the presence of the SST structure, but not its length. Theoretically, when mysqldump method is used this structure can be created only in order to point to the IST (with zero length of the SST part).

Therefore, in the Galera code we should be ready to restart SST after failing to perform IST - to be protected against failures in the future, when implementation of the wsrep_sst_prepare function may change. And, especially, when mysqldump is used as state transfer method.

When new node joining the cluster, it may trying to avoid unnecessary SST request. For example, when its seqno matches the group seqno. However, the heuristic that selects the donor node does not give us a 100% guarantee that seqno does not move forward while the new node joining the cluster.

Therefore, if we have only a request for the IST (but we do not have a request for SST), then we need to informing new node, that it should prepare to receive SST.

Especially because we need this signal to notify the user of the impossibility to perform the SST instead of IST in the current version of the server (when xtrabackup or rsynch was selected as the state transfer method).

In addition, if the IST request was canceled due to an error at the GCS level or by initiative of the server, and if the node remain in the S_JOINING state, then we must return it to the S_CONNECTED state.
