### PR TITLE
- galera-3.16 introduces an inbuilt concept of desync_count.

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -223,6 +223,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     state_.add_transition(Transition(S_JOINED, S_CLOSING));
     state_.add_transition(Transition(S_JOINED, S_CONNECTED));
     state_.add_transition(Transition(S_JOINED, S_SYNCED));
+    state_.add_transition(Transition(S_JOINED, S_DONOR));
 
     state_.add_transition(Transition(S_SYNCED, S_CLOSING));
     state_.add_transition(Transition(S_SYNCED, S_CONNECTED));

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1193,7 +1193,9 @@ static void *gcs_recv_thread (void *arg)
         struct gcs_repl_act** repl_act_ptr;
         struct gcs_act_rcvd   rcvd;
 
-        ret = gcs_core_recv (conn->core, &rcvd, conn->timeout);
+        bool* sync_sent = (conn->state == GCS_CONN_DONOR
+                           ? &conn->sync_sent : NULL);
+        ret = gcs_core_recv (conn->core, &rcvd, conn->timeout, sync_sent);
 
         if (gu_unlikely(ret <= 0)) {
 

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1049,7 +1049,8 @@ static long core_msg_causal(gcs_core_t* conn,
 /*! Receives action */
 ssize_t gcs_core_recv (gcs_core_t*          conn,
                        struct gcs_act_rcvd* recv_act,
-                       long long            timeout)
+                       long long            timeout,
+                       bool*                sync_sent_ref)
 {
 //    struct gcs_act_rcvd  recv_act;
     struct gcs_recv_msg* recv_msg = &conn->recv_msg;
@@ -1110,6 +1111,20 @@ ssize_t gcs_core_recv (gcs_core_t*          conn,
         case GCS_MSG_FLOW:
             ret = core_msg_to_action (conn, recv_msg, &recv_act->act);
             assert (ret == recv_act->act.buf_len || ret <= 0);
+            if (ret == -1) {
+                /* This is to flag transition of node from JOINED -> DONOR.
+                Generally node goes from DONOR -> JOINED -> SYNCED but if
+                parallel desync request is recieved while node is in JOINED
+                state and it is processed before SYNCED message then node
+                can go from JOINED to DONOR state by-passing SYNCED state.
+                In such case we need to ignore SYNC request that is lying
+                from previous state transition and reset sync_sent so that
+                connection restart sending the request. */
+                if (sync_sent_ref) {
+                    *sync_sent_ref = false;
+                }
+                ret = 0;
+            }
             break;
         case GCS_MSG_CAUSAL:
             ret = core_msg_causal(conn, recv_msg);

--- a/gcs/src/gcs_core.hpp
+++ b/gcs/src/gcs_core.hpp
@@ -125,7 +125,8 @@ gcs_core_send (gcs_core_t*          core,
 extern ssize_t
 gcs_core_recv (gcs_core_t*          conn,
                struct gcs_act_rcvd* recv_act,
-               long long            timeout);
+               long long            timeout,
+               bool*                sync_sent_ref = NULL);
 
 /* group protocol version */
 extern gcs_proto_t

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -805,7 +805,15 @@ gcs_group_handle_sync_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
         return (sender_idx == group->my_idx);
     }
     else {
-        if (GCS_NODE_STATE_SYNCED != sender->status) {
+        int ret = 0;
+
+        if (GCS_NODE_STATE_DONOR == sender->status) {
+            gu_info ("SYNC message ignored as node %d.%d (%s) was"
+                     " re-transitioned to DONOR mode before it synced.",
+                     sender_idx, sender->segment, sender->name);
+            ret = -1;
+        }
+        else if (GCS_NODE_STATE_SYNCED != sender->status) {
             gu_warn ("SYNC message sender from non-JOINED %d.%d (%s). Ignored.",
                      sender_idx, sender->segment, sender->name);
         }
@@ -813,7 +821,8 @@ gcs_group_handle_sync_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
             gu_debug ("Redundant SYNC message from %d.%d (%s).",
                       sender_idx, sender->segment, sender->name);
         }
-        return 0;
+
+        return ret;
     }
 }
 


### PR DESCRIPTION
  This count act as reference count and node is resynced
  only when the count reaches 0. This solves a major issues
  of parallel desync operation that can cause node to
  resync even when parallel desync operation is active.

  This change introduced another major bug in the flow.
  Imagine a case that node is being re-synced which follows
  following state change path:
  DONOR -> JOINED -> SYNCED.

  Let's say while node is processing DONOR -> JOINED state
  transition parallel desync request is made.
  This desync request get added to queue even before SYNCED
  request which means next time donor will process DESYNC
  request before SYNCED request and will cause a transition
  of node from JOINED -> DONOR (by-passing SYNCED).
  SYNCED message when recived will be ignored.

  This transition from JOINED -> DONOR was missing in state
  transition map and if SYNC message is being ignored in
  such special case then we need to ensure that it is
  termed success by marking sync_sent = false so that
  next time node can continue to generate SYNC message.
