### PR TITLE
- #PXC-585: WSREP BF-BF conflicts causes server to crash.

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1494,6 +1494,7 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
                 case S_SYNCED:
                     state_.shift_to(S_SYNCED);
                     synced_cb_(app_ctx_);
+                    GU_DBUG_SYNC_WAIT("after_synced_cb");
                     break;
                 default:
                     log_debug << "next_state " << next_state;
@@ -1590,6 +1591,7 @@ void galera::ReplicatorSMM::process_sync(wsrep_seqno_t seqno_l)
 
     state_.shift_to(S_SYNCED);
     synced_cb_(app_ctx_);
+    GU_DBUG_SYNC_WAIT("after_synced_cb");
     local_monitor_.leave(lo);
 }
 


### PR DESCRIPTION
MW-258 test sometimes fails (not at every startup). Currently we have only the error in the TC caused by the fact that before checking variable wsrep_desync_count we need to wait for "synced" callback, since the variable wsrep_desync_count shows the actual state of the desync counter, but synchronization takes some time.

PXC part of this patch is available here: https://github.com/percona/percona-xtradb-cluster/pull/155
