### PR TITLE
- #PXC-585: WSREP BF-BF conflicts causes server to crash.

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1668,6 +1668,7 @@ void galera::ReplicatorSMM::desync()
             local_monitor_.enter(lo);
             if (state_() != S_DONOR) state_.shift_to(S_DONOR);
             local_monitor_.leave(lo);
+            GU_DBUG_SYNC_WAIT("wsrep_desync_left_local_monitor");
         }
         else if (ret != -EAGAIN)
         {


### PR DESCRIPTION
MW-258 test sometimes fails with MDL BF-BF confict (not at every startup).

The main reason for this problem is that we need to remove protection against repeated calls of the wsrep->pause() on the same node, since otherwise we lose protection against conflicts, which is provided by the local_monitor and commit_monitor in the Galera code. Previously, we used a similar defense (implemented via counter variable + mutex) against repeated calls to the wsrep->desync() and wsrep->pause() functions, but it is irrelevant to the new version of the Galera, because it have an internal desync counter. Therefore, we need to remove this extra protection.

Also MW-258 TC occasionally fails due to the fact that before final checking of the wsrep_desync_count variable we need to wait until node re-synched, because the wsrep_desync_count variable shows the actual state of the desync counter, but synchronization takes some time.

PXC part of this patch is available here: https://github.com/percona/percona-xtradb-cluster/pull/157
