### PR TITLE
- #PXC-601: show status while updating group state can cause an assert (likely race)

### DIFF
--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -16,6 +16,7 @@
 #include <assert.h>
 
 #include <galerautils.h>
+#include "gu_debug_sync.hpp"
 
 #include "gcs_priv.hpp"
 #include "gcs_params.hpp"
@@ -1426,6 +1427,9 @@ long gcs_close (gcs_conn_t *conn)
     }
     /* recv_thread() is supposed to set state to CLOSED when exiting */
     assert (GCS_CONN_CLOSED == conn->state);
+#ifdef GU_DBUG_ON
+    GU_DBUG_SYNC_WAIT("gcs_close_before_exit");
+#endif
     return ret;
 }
 
@@ -1993,6 +1997,9 @@ void gcs_get_status(gcs_conn_t* conn, gu::Status& status)
 {
     if (conn->state < GCS_CONN_CLOSED)
     {
+#ifdef GU_DBUG_ON
+        GU_DBUG_SYNC_WAIT("gcs_get_status");
+#endif
         gcs_core_get_status(conn->core, status);
     }
 }

--- a/gcs/src/gcs_group.hpp
+++ b/gcs/src/gcs_group.hpp
@@ -65,6 +65,12 @@ typedef struct gcs_group
     gcs_state_quorum_t quorum;
     int last_applied_proto_ver;
 
+    // Mutex to protect from reading the current node index (my_idx)
+    // by SHOW STATUS helper function (gcs_group_get_status) while it
+    // is temporarily in an undefined state (-1):
+
+    gu_mutex_t index_lock;
+
     gcs_group() : gcs_proto_ver(0), repl_proto_ver(0), appl_proto_ver(0) { }
 
 }
@@ -248,6 +254,6 @@ gcs_group_find_donor(const gcs_group_t* group,
                      const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno);
 
 extern void
-gcs_group_get_status(const gcs_group_t* group, gu::Status& status);
+gcs_group_get_status(gcs_group_t* group, gu::Status& status);
 
 #endif /* _gcs_group_h_ */


### PR DESCRIPTION
The gcs_group_get_status function does not check that the group->my_idx can be equal to -1 (for example, when node receives self-leave message during non-primary state or technically due to implementation details of the gcs_group_handle_comp_msg function). Therefore, gcs_group_get_status function refers to memory beyond the array, which leads to SIGFAULT during execution of the to_string function.

To fix this error we should not read desync counter until the gcs_group_handle_comp_msg function returns the group->my_idx to definite state.

In addition, we should handle the situation where node is in the non-primary state and we got self-leave message. In this case node is desynchronized from the cluster, therefore I propose to return desync counter = 1.

PXC part of this patch is available here: https://github.com/percona/percona-xtradb-cluster/pull/173
