### PR TITLE
- #PXC-426: Race condition during IST

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1458,9 +1458,29 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
         if (st_required && app_wants_st)
         {
             // GCache::Seqno_reset() happens here
-            request_state_transfer (recv_ctx,
-                                    group_uuid, group_seqno, app_req,
-                                    app_req_len);
+            long ret =
+                request_state_transfer (recv_ctx,
+                                        group_uuid, group_seqno, app_req,
+                                        app_req_len);
+
+            if (ret < 0 || sst_state_ == SST_CANCELED)
+            {
+                // If the IST/SST request was canceled due to error
+                // at the GCS level or if request was canceled by another
+                // thread (by initiative of the server), and if the node
+                // remain in the S_JOINING state, then we must return it
+                // to the S_CONNECTED state (to the original state, which
+                // exist before the request_state_transfer started).
+                // In other words, if state transfer failed then we move
+                // the node back to the old state. This will help us to
+                // restart SST, especially if mysqldump method is used
+                // for state transfer:
+
+                if (state_() == S_JOINING)
+                {
+                    state_.shift_to(S_CONNECTED);
+                }
+            }
         }
         else
         {
@@ -1501,8 +1521,13 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
             st_.set(state_uuid_, WSREP_SEQNO_UNDEFINED);
         }
 
-        if (state_() == S_JOINING && sst_state_ != SST_NONE
-                                  && sst_state_ != SST_CANCELED)
+        // We should not try to joining the cluster at the GCS level,
+        // if the node is not in the S_JOINING state, or if we did not
+        // make the IST/SST request, or if it is failed. In other words,
+        // any state (SST_NONE, SST_CANCELED) other than SST_WAIT not
+        // require us to sending the JOIN message at the GCS level:
+
+        if (sst_state_ == SST_WAIT && state_() == S_JOINING)
         {
             /* There are two reasons we can be here:
              * 1) we just got state transfer in request_state_transfer() above;

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -475,7 +475,7 @@ namespace galera
 
         long send_state_request (const StateRequest* req, const bool unsafe);
 
-        void request_state_transfer (void* recv_ctx,
+        long request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,
                                      wsrep_seqno_t       group_seqno,
                                      const void*         sst_req,

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -414,12 +414,39 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                 try
                 {
                     gcache_.seqno_lock(istr.last_applied() + 1);
+
+                    // We can use Galera debugging facility to simulate
+                    // unexpected shift of the donor seqno:
+#ifdef GU_DBUG_ON
+                    GU_DBUG_EXECUTE("process_state_req_ist",
+                                    throw gu::NotFound(););
+#endif
                 }
                 catch(gu::NotFound& nf)
                 {
                     log_info << "IST first seqno " << istr.last_applied() + 1
                              << " not found from cache, falling back to SST";
                     // @todo: close IST channel explicitly
+
+                    // When new node joining the cluster, it may trying to avoid
+                    // unnecessary SST request. However, the heuristic algorithm,
+                    // which selects the donor node, does not give us a 100%
+                    // guarantee that seqno will not move forward while new
+                    // node sending request to joining the cluster. Therefore,
+                    // if seqno had gone forward, and if we have only the IST
+                    // request (without the SST part), then we need to informing
+                    // new node that it should prepare to receive SST and re-send
+                    // SST request (if the server supports it):
+
+                    if (streq->sst_len() == 0)
+                    {
+                        log_info << "IST canceled because the donor seqno had "
+                                    "moved forward, but the SST request was not "
+                                    "prepared by the joiner node.";
+                        rcode = -ENODATA;
+                        goto out;
+                    }
+
                     goto full_sst;
                 }
 
@@ -621,7 +648,27 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
                                           ist_uuid, ist_seqno, &seqno_l);
         if (ret < 0)
         {
-            if (!retry_str(ret))
+            if (ret == -ENODATA)
+            {
+                // Although the current state has lagged behind state
+                // of the group, we can save it for the next attempt
+                // of the joining cluster, because we do not know how
+                // other nodes will finish their work:
+
+                if (unsafe)
+                {
+                   st_.mark_safe();
+                }
+
+                log_fatal << "State transfer request failed unrecoverably "
+                             "because the donor seqno had gone forward "
+                             "during IST, but SST request was not prepared "
+                             "from our side due to selected state transfer "
+                             "method (which do not supports SST during "
+                             "node operation). Restart required.";
+                abort();
+            }
+            else if (!retry_str(ret))
             {
                 log_error << "Requesting state transfer failed: "
                           << ret << "(" << strerror(-ret) << ")";
@@ -677,7 +724,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 
         st_.set(state_uuid_, STATE_SEQNO());
 
-        if (state_() > S_CLOSING)
+        if (ret != -ENODATA && state_() > S_CLOSING)
         {
             if (!unsafe)
             {
@@ -703,7 +750,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 }
 
 
-void
+long
 ReplicatorSMM::request_state_transfer (void* recv_ctx,
                                        const wsrep_uuid_t& group_uuid,
                                        wsrep_seqno_t const group_seqno,
@@ -747,10 +794,18 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     // We should not wait for completion of the SST or to handle it
     // results if an error has occurred when sending the request:
 
-    if (send_state_request(req, unsafe) < 0)
+    long ret = send_state_request(req, unsafe);
+    if (ret < 0)
     {
+        // If the state transfer request failed, then
+        // we need to close the IST receiver:
+        if (ist_prepared_)
+        {
+           ist_prepared_ = false;
+           (void)ist_receiver_.finished();
+        }
         delete req;
-        return;
+        return ret;
     }
 
     GU_DBUG_SYNC_WAIT("after_send_state_request");
@@ -783,7 +838,17 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             }
 
             close();
-            return;
+
+            // If the state transfer request failed, then
+            // we need to close the IST receiver:
+
+            if (ist_prepared_)
+            {
+                ist_prepared_ = false;
+                (void)ist_receiver_.finished();
+            }
+
+            return -ECANCELED;
         }
         else if (sst_uuid_ != group_uuid)
         {
@@ -845,7 +910,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             ist_receiver_.ready();
             recv_IST(recv_ctx);
 
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -861,7 +926,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
         }
         else
         {
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -885,6 +950,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     }
 
     delete req;
+    return 0;
 }
 
 

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1111,7 +1111,7 @@ ssize_t gcs_core_recv (gcs_core_t*          conn,
         case GCS_MSG_FLOW:
             ret = core_msg_to_action (conn, recv_msg, &recv_act->act);
             assert (ret == recv_act->act.buf_len || ret <= 0);
-            if (ret == -1) {
+            if (ret <= 0) {
                 /* This is to flag transition of node from JOINED -> DONOR.
                 Generally node goes from DONOR -> JOINED -> SYNCED but if
                 parallel desync request is recieved while node is in JOINED


### PR DESCRIPTION
The node lost connectivity with other nodes in the cluster (for some time) due to network problems. Therefore, it needs to run IST to synchronize their state with cluster, but the IST request was failed.

During node operation IST starts only when local_seqno < group_seqno while configuration change is detected in the cluster (this detected at the GCS layer, then the GCS_ACT_CONF message is sent to the action source handler and processed in the Replicator).

This occurs after the cluster becomes non-primary state, and then returns to the state with primary component. Alternatively, IST started when node lost connectivity with the cluster (but this is recoverable condition) and then it re-joined the cluster.

However, if we already have large network delays and packet losses, then during IST we can encounter situation when seqno on the donor node has moved forward so much that IST is not possible and we need to run "full" SST request.

The immediate cause of the PXC-426 error is the inability of the PXC to run SST (using methods that different from mysqldump) on the working node. PXC and Galera written in such way that we need a full restart before launching new SST.

Therefore, we need to show the user a message that indicates that we need to perform SST after restart and to stop working. However, currently the server continues to work, even when the synchronization of the node is no longer possible and it cannot continue normal operation in a cluster.

However, why we encountered situation when seqno had goes forward during IST?

The fact, that the heuristic algorithm of the donor selection, which implemented in the GCS, contains the flaw, and may choose as a donor such node, where seqno can go forward before the IST request will be received.

Therefore, we need to improve the heuristics in the donor node selection algorithm (in the group_find_ist_donor function) to make this flaw less likely.

And since the heuristic that selects the donor node does not give us a 100% guarantee that seqno does not move forward while the new node joining the cluster, if we have only a request for the IST (but we do not have a request for SST), then we need to informing new node, that it should prepare to receive SST.

Especially because we need this signal to notify the user of the impossibility to perform the SST instead of IST in the current version of the server (when xtrabackup or rsynch was selected as the state transfer method).

It is difficult to assess the situation from which we have only the server logs - but it is possible that the correction of the heuristic would not help us to eliminate all cases when situation like the PXC-426 can arise.

In this case, as I have said above, we need to tell the user that the IST is impossible and server restart is required (because we cannot change PXC architecture quickly, without rewriting large fragments of its code).

Theoretically, a similar diagnostic and error also possible if the MySQL server does not prepared structures for the SST in the view callback (in the wsrep_view_handler_cb function) after restart of the node - when it returns only the structures for IST. For example, when new node joining the cluster, it may trying to avoid unnecessary SST request when its seqno matches the group seqno.

But in the current version of PXC this should not happen after node restart, because after restrart the wsrep_sst_prepare function (which called from wsrep_view_handler_cb) always returns a non-zero value as length of the SST request and node always prepared both for the SST and IST.

However, the assertion in the wsrep_view_handler_cb function only checks for the presence of the SST structure, but not its length. Theoretically, when mysqldump method is used this structure can be created only in order to point to the IST (with zero length of the SST part).

Therefore, in the Galera code we should be ready to restart SST after failing to perform IST - to be protected against failures in the future, when implementation of the wsrep_sst_prepare function may change. And, especially, when mysqldump is used as state transfer method.

In addition, if the IST request was canceled due to an error at the GCS level or by initiative of the server, and if the node remain in the S_JOINING state, then we must return it to the S_CONNECTED state.

Related PXC patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/133
