### PR TITLE
- #PXC-426: Race condition during IST

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1458,9 +1458,29 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
         if (st_required && app_wants_st)
         {
             // GCache::Seqno_reset() happens here
-            request_state_transfer (recv_ctx,
-                                    group_uuid, group_seqno, app_req,
-                                    app_req_len);
+            long ret =
+                request_state_transfer (recv_ctx,
+                                        group_uuid, group_seqno, app_req,
+                                        app_req_len);
+
+            if (ret < 0 || sst_state_ == SST_CANCELED)
+            {
+                // If the IST/SST request was canceled due to error
+                // at the GCS level or if request was canceled by another
+                // thread (by initiative of the server), and if the node
+                // remain in the S_JOINING state, then we must return it
+                // to the S_CONNECTED state (to the original state, which
+                // exist before the request_state_transfer started).
+                // In other words, if state transfer failed then we move
+                // the node back to the old state. This will help us to
+                // restart SST, especially if mysqldump method is used
+                // for state transfer:
+
+                if (state_() == S_JOINING)
+                {
+                    state_.shift_to(S_CONNECTED);
+                }
+            }
         }
         else
         {
@@ -1501,8 +1521,13 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
             st_.set(state_uuid_, WSREP_SEQNO_UNDEFINED);
         }
 
-        if (state_() == S_JOINING && sst_state_ != SST_NONE
-                                  && sst_state_ != SST_CANCELED)
+        // We should not try to joining the cluster at the GCS level,
+        // if the node is not in the S_JOINING state, or if we did not
+        // make the IST/SST request, or if it is failed. In other words,
+        // any state (SST_NONE, SST_CANCELED) other than SST_WAIT not
+        // require us to sending the JOIN message at the GCS level:
+
+        if (sst_state_ == SST_WAIT && state_() == S_JOINING)
         {
             /* There are two reasons we can be here:
              * 1) we just got state transfer in request_state_transfer() above;

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1458,29 +1458,9 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
         if (st_required && app_wants_st)
         {
             // GCache::Seqno_reset() happens here
-            long ret =
-                request_state_transfer (recv_ctx,
-                                        group_uuid, group_seqno, app_req,
-                                        app_req_len);
-
-            if (ret < 0 || sst_state_ == SST_CANCELED)
-            {
-                // If the IST/SST request was canceled due to error
-                // at the GCS level or if request was canceled by another
-                // thread (by initiative of the server), and if the node
-                // remain in the S_JOINING state, then we must return it
-                // to the S_CONNECTED state (to the original state, which
-                // exist before the request_state_transfer started).
-                // In other words, if state transfer failed then we move
-                // the node back to the old state. This will help us to
-                // restart SST, especially if mysqldump method is used
-                // for state transfer:
-
-                if (state_() == S_JOINING)
-                {
-                    state_.shift_to(S_CONNECTED);
-                }
-            }
+            request_state_transfer (recv_ctx,
+                                    group_uuid, group_seqno, app_req,
+                                    app_req_len);
         }
         else
         {
@@ -1521,13 +1501,8 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
             st_.set(state_uuid_, WSREP_SEQNO_UNDEFINED);
         }
 
-        // We should not try to joining the cluster at the GCS level,
-        // if the node is not in the S_JOINING state, or if we did not
-        // make the IST/SST request, or if it is failed. In other words,
-        // any state (SST_NONE, SST_CANCELED) other than SST_WAIT not
-        // require us to sending the JOIN message at the GCS level:
-
-        if (sst_state_ == SST_WAIT && state_() == S_JOINING)
+        if (state_() == S_JOINING && sst_state_ != SST_NONE
+                                  && sst_state_ != SST_CANCELED)
         {
             /* There are two reasons we can be here:
              * 1) we just got state transfer in request_state_transfer() above;

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -475,7 +475,7 @@ namespace galera
 
         long send_state_request (const StateRequest* req, const bool unsafe);
 
-        long request_state_transfer (void* recv_ctx,
+        void request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,
                                      wsrep_seqno_t       group_seqno,
                                      const void*         sst_req,

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -475,7 +475,7 @@ namespace galera
 
         long send_state_request (const StateRequest* req, const bool unsafe);
 
-        void request_state_transfer (void* recv_ctx,
+        long request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,
                                      wsrep_seqno_t       group_seqno,
                                      const void*         sst_req,

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -414,12 +414,39 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                 try
                 {
                     gcache_.seqno_lock(istr.last_applied() + 1);
+
+                    // We can use Galera debugging facility to simulate
+                    // unexpected shift of the donor seqno:
+#ifdef GU_DBUG_ON
+                    GU_DBUG_EXECUTE("process_state_req_ist",
+                                    throw gu::NotFound(););
+#endif
                 }
                 catch(gu::NotFound& nf)
                 {
                     log_info << "IST first seqno " << istr.last_applied() + 1
                              << " not found from cache, falling back to SST";
                     // @todo: close IST channel explicitly
+
+                    // When new node joining the cluster, it may trying to avoid
+                    // unnecessary SST request. However, the heuristic algorithm,
+                    // which selects the donor node, does not give us a 100%
+                    // guarantee that seqno will not move forward while new
+                    // node sending request to joining the cluster. Therefore,
+                    // if seqno had gone forward, and if we have only the IST
+                    // request (without the SST part), then we need to informing
+                    // new node that it should prepare to receive SST and re-send
+                    // SST request (if the server supports it):
+
+                    if (streq->sst_len() == 0)
+                    {
+                        log_info << "IST canceled because the donor seqno had "
+                                    "moved forward, but the SST request was not "
+                                    "prepared by the joiner node.";
+                        rcode = -ENODATA;
+                        goto out;
+                    }
+
                     goto full_sst;
                 }
 
@@ -621,7 +648,27 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
                                           ist_uuid, ist_seqno, &seqno_l);
         if (ret < 0)
         {
-            if (!retry_str(ret))
+            if (ret == -ENODATA)
+            {
+                // Although the current state has lagged behind state
+                // of the group, we can save it for the next attempt
+                // of the joining cluster, because we do not know how
+                // other nodes will finish their work:
+
+                if (unsafe)
+                {
+                   st_.mark_safe();
+                }
+
+                log_fatal << "State transfer request failed unrecoverably "
+                             "because the donor seqno had gone forward "
+                             "during IST, but SST request was not prepared "
+                             "from our side due to selected state transfer "
+                             "method (which do not supports SST during "
+                             "node operation). Restart required.";
+                abort();
+            }
+            else if (!retry_str(ret))
             {
                 log_error << "Requesting state transfer failed: "
                           << ret << "(" << strerror(-ret) << ")";
@@ -677,7 +724,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 
         st_.set(state_uuid_, STATE_SEQNO());
 
-        if (state_() > S_CLOSING)
+        if (ret != -ENODATA && state_() > S_CLOSING)
         {
             if (!unsafe)
             {
@@ -703,7 +750,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 }
 
 
-void
+long
 ReplicatorSMM::request_state_transfer (void* recv_ctx,
                                        const wsrep_uuid_t& group_uuid,
                                        wsrep_seqno_t const group_seqno,
@@ -747,10 +794,18 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     // We should not wait for completion of the SST or to handle it
     // results if an error has occurred when sending the request:
 
-    if (send_state_request(req, unsafe) < 0)
+    long ret = send_state_request(req, unsafe);
+    if (ret < 0)
     {
+        // If the state transfer request failed, then
+        // we need to close the IST receiver:
+        if (ist_prepared_)
+        {
+           ist_prepared_ = false;
+           (void)ist_receiver_.finished();
+        }
         delete req;
-        return;
+        return ret;
     }
 
     GU_DBUG_SYNC_WAIT("after_send_state_request");
@@ -783,7 +838,17 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             }
 
             close();
-            return;
+
+            // If the state transfer request failed, then
+            // we need to close the IST receiver:
+
+            if (ist_prepared_)
+            {
+                ist_prepared_ = false;
+                (void)ist_receiver_.finished();
+            }
+
+            return -ECANCELED;
         }
         else if (sst_uuid_ != group_uuid)
         {
@@ -845,7 +910,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             ist_receiver_.ready();
             recv_IST(recv_ctx);
 
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -861,7 +926,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
         }
         else
         {
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -885,6 +950,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     }
 
     delete req;
+    return 0;
 }
 
 

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -414,12 +414,39 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                 try
                 {
                     gcache_.seqno_lock(istr.last_applied() + 1);
+
+                    // We can use Galera debugging facility to simulate
+                    // unexpected shift of the donor seqno:
+#ifdef GU_DBUG_ON
+                    GU_DBUG_EXECUTE("simulate_seqno_shift",
+                                    throw gu::NotFound(););
+#endif
                 }
                 catch(gu::NotFound& nf)
                 {
                     log_info << "IST first seqno " << istr.last_applied() + 1
                              << " not found from cache, falling back to SST";
                     // @todo: close IST channel explicitly
+
+                    // When new node joining the cluster, it may trying to avoid
+                    // unnecessary SST request. However, the heuristic algorithm,
+                    // which selects the donor node, does not give us a 100%
+                    // guarantee that seqno will not move forward while new
+                    // node sending request to joining the cluster. Therefore,
+                    // if seqno had gone forward, and if we have only the IST
+                    // request (without the SST part), then we need to informing
+                    // new node that it should prepare to receive SST and re-send
+                    // SST request (if the server supports it):
+
+                    if (streq->sst_len() == 0)
+                    {
+                        log_info << "IST canceled because the donor seqno had "
+                                    "moved forward, but the SST request was not "
+                                    "prepared by the joiner node.";
+                        rcode = -ENODATA;
+                        goto out;
+                    }
+
                     goto full_sst;
                 }
 
@@ -621,7 +648,27 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
                                           ist_uuid, ist_seqno, &seqno_l);
         if (ret < 0)
         {
-            if (!retry_str(ret))
+            if (ret == -ENODATA)
+            {
+                // Although the current state has lagged behind state
+                // of the group, we can save it for the next attempt
+                // of the joining cluster, because we do not know how
+                // other nodes will finish their work:
+
+                if (unsafe)
+                {
+                   st_.mark_safe();
+                }
+
+                log_fatal << "State transfer request failed unrecoverably "
+                             "because the donor seqno had gone forward "
+                             "during IST, but SST request was not prepared "
+                             "from our side due to selected state transfer "
+                             "method (which do not supports SST during "
+                             "node operation). Restart required.";
+                abort();
+            }
+            else if (!retry_str(ret))
             {
                 log_error << "Requesting state transfer failed: "
                           << ret << "(" << strerror(-ret) << ")";
@@ -677,7 +724,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 
         st_.set(state_uuid_, STATE_SEQNO());
 
-        if (state_() > S_CLOSING)
+        if (ret != -ENODATA && state_() > S_CLOSING)
         {
             if (!unsafe)
             {
@@ -703,7 +750,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 }
 
 
-void
+long
 ReplicatorSMM::request_state_transfer (void* recv_ctx,
                                        const wsrep_uuid_t& group_uuid,
                                        wsrep_seqno_t const group_seqno,
@@ -747,10 +794,18 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     // We should not wait for completion of the SST or to handle it
     // results if an error has occurred when sending the request:
 
-    if (send_state_request(req, unsafe) < 0)
+    long ret = send_state_request(req, unsafe);
+    if (ret < 0)
     {
+        // If the state transfer request failed, then
+        // we need to close the IST receiver:
+        if (ist_prepared_)
+        {
+           ist_prepared_ = false;
+           (void)ist_receiver_.finished();
+        }
         delete req;
-        return;
+        return ret;
     }
 
     GU_DBUG_SYNC_WAIT("after_send_state_request");
@@ -783,7 +838,9 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             }
 
             close();
-            return;
+
+            delete req;
+            return -ECANCELED;
         }
         else if (sst_uuid_ != group_uuid)
         {
@@ -845,7 +902,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             ist_receiver_.ready();
             recv_IST(recv_ctx);
 
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -861,7 +918,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
         }
         else
         {
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -885,6 +942,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     }
 
     delete req;
+    return 0;
 }
 
 

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1111,7 +1111,7 @@ ssize_t gcs_core_recv (gcs_core_t*          conn,
         case GCS_MSG_FLOW:
             ret = core_msg_to_action (conn, recv_msg, &recv_act->act);
             assert (ret == recv_act->act.buf_len || ret <= 0);
-            if (ret <= 0) {
+            if (ret == -1) {
                 /* This is to flag transition of node from JOINED -> DONOR.
                 Generally node goes from DONOR -> JOINED -> SYNCED but if
                 parallel desync request is recieved while node is in JOINED

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1111,7 +1111,7 @@ ssize_t gcs_core_recv (gcs_core_t*          conn,
         case GCS_MSG_FLOW:
             ret = core_msg_to_action (conn, recv_msg, &recv_act->act);
             assert (ret == recv_act->act.buf_len || ret <= 0);
-            if (ret == -1) {
+            if (ret <= 0) {
                 /* This is to flag transition of node from JOINED -> DONOR.
                 Generally node goes from DONOR -> JOINED -> SYNCED but if
                 parallel desync request is recieved while node is in JOINED

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -747,19 +747,6 @@ gcs_group_handle_join_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
 
             if (from_donor && peer_idx == group->my_idx &&
                 GCS_NODE_STATE_JOINER == group->nodes[peer_idx].status) {
-
-                // If there is an ENODATA error code, then it is indication
-                // that state on the joiner node was moved forward too much
-                // and we need to initiate a full SST instead of IST.
-                // We should not treat this condition as a fatal error
-                // (decision on this matter should take higher levels,
-                // for example, Replicator or the server):
-
-                if (seqno == -ENODATA)
-                {
-                    return -ENODATA;
-                }
-
                 // this node will be waiting for SST forever. If it has only
                 // one recv thread there is no (generic) way to wake it up.
                 gu_fatal ("Will never receive state. Need to abort.");
@@ -1184,23 +1171,15 @@ group_find_ist_donor (const gcs_group_t* const group,
         return -1;
     }
 
-    // The safety_gap is the heuristically calculated distance
-    // to which the group seqno can be moved forward in process
-    // of the delivery the IST request to the donor node. We should
-    // use difference "ist_seqno - safety_gap" (instead of ist_seqno)
-    // to search of the donor node - to avoid situations where seqno
-    // on the donor node changed so much that IST is not possible
-    // (and we need to run full SST instead):
-
     if (str_len) {
         // find ist donor by name.
         idx = group_find_ist_donor_by_name_in_string(
-            group, joiner_idx, str, str_len, ist_seqno - safety_gap, status);
+            group, joiner_idx, str, str_len, ist_seqno, status);
         if (idx >= 0) return idx;
     }
     // find ist donor by status.
     idx = group_find_ist_donor_by_state(
-        group, joiner_idx, ist_seqno - safety_gap, status);
+        group, joiner_idx, ist_seqno, status);
     if (idx >= 0) return idx;
     return -1;
 }

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -747,6 +747,25 @@ gcs_group_handle_join_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
 
             if (from_donor && peer_idx == group->my_idx &&
                 GCS_NODE_STATE_JOINER == group->nodes[peer_idx].status) {
+
+                // If there is an ENODATA error code, then it is indication
+                // that state on the joiner node was moved forward too much
+                // and we need to initiate a full SST instead of IST.
+                // We should not treat this condition as a fatal error
+                // (decision on this matter should take higher levels,
+                // for example, Replicator or the server):
+
+                if (seqno == -ENODATA)
+                {
+                    gu_fatal ("State transfer request failed unrecoverably "
+                              "because the donor seqno had gone forward "
+                              "during IST, but SST request was not prepared "
+                              "from our side due to selected state transfer "
+                              "method (which do not supports SST during "
+                              "node operation). Restart required.");
+                    return -ENOTRECOVERABLE;
+                }
+
                 // this node will be waiting for SST forever. If it has only
                 // one recv thread there is no (generic) way to wake it up.
                 gu_fatal ("Will never receive state. Need to abort.");
@@ -1144,7 +1163,8 @@ group_find_ist_donor (const gcs_group_t* const group,
                       int joiner_idx,
                       const char* str, int str_len,
                       gcs_seqno_t ist_seqno,
-                      gcs_node_state_t status)
+                      gcs_node_state_t status,
+                      const bool ist_only)
 {
     int idx = -1;
 
@@ -1165,7 +1185,10 @@ group_find_ist_donor (const gcs_group_t* const group,
              (long long)ist_seqno, (long long)lowest_cached_seqno,
              (long long)conf_seqno, (long long)safe_ist_seqno);
 
-    if (ist_seqno < safe_ist_seqno) {
+    // We should ignore this heuristic if the request contains only a IST part,
+    // since otherwise we cannot fulfill the request:
+
+    if (ist_seqno < safe_ist_seqno && ! ist_only) {
         // unsafe to perform ist.
         gu_debug("fallback to sst. ist_seqno < safe_ist_seqno");
         return -1;
@@ -1189,7 +1212,8 @@ gcs_group_find_donor(const gcs_group_t* group,
                      int const str_version,
                      int const joiner_idx,
                      const char* const donor_string, int const donor_len,
-                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno)
+                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno,
+                     const bool ist_only)
 {
     static gcs_node_state_t const min_donor_state = GCS_NODE_STATE_SYNCED;
 
@@ -1205,7 +1229,8 @@ gcs_group_find_donor(const gcs_group_t* group,
                                          joiner_idx,
                                          donor_string, donor_len,
                                          ist_seqno,
-                                         min_donor_state);
+                                         min_donor_state,
+                                         ist_only);
     }
     if (donor_idx < 0)
     {
@@ -1235,7 +1260,8 @@ group_select_donor (gcs_group_t* group,
                     int const joiner_idx,
                     const char* const donor_string,
                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno,
-                    bool const desync)
+                    const bool desync,
+                    const bool ist_only)
 {
     static gcs_node_state_t const min_donor_state = GCS_NODE_STATE_SYNCED;
     int  donor_idx;
@@ -1261,7 +1287,8 @@ group_select_donor (gcs_group_t* group,
                                          str_version,
                                          joiner_idx,
                                          donor_string, donor_len,
-                                         ist_uuid, ist_seqno);
+                                         ist_uuid, ist_seqno,
+                                         ist_only);
     }
 
     if (donor_idx >= 0) {
@@ -1391,10 +1418,54 @@ gcs_group_handle_state_request (gcs_group_t*         group,
         }
     }
 
+    // We need to perform a partial analysis of the application
+    // request to find out that it contains the SST part (not just IST):
+
+    int app_req_len = act->act.buf_len - (donor_name_len + 1);
+    char * app_req =
+        reinterpret_cast<char*>(const_cast<void*>(act->act.buf)) +
+        (donor_name_len + 1);
+
+    // Requests of the "zero" version contain only the SST part.
+    // They can be distinguished from the first version of the requests
+    // by the lack of the "magic" prefix:
+
+    int sst_len = app_req_len;
+    int magic_len = strlen("STRv1");
+
+    if (app_req_len > magic_len && !strncmp(app_req, "STRv1", magic_len))
+    {
+        // Request of the first version contain an explicit length
+        // of the SST part:
+
+        int offset = magic_len + 1;
+        sst_len = gtohl(*(reinterpret_cast<uint32_t*>(app_req + offset)));
+
+        // To facilitate debugging, we may need involuntary stimulation
+        // of the lack of SST part in the request:
+
+#ifdef GU_DBUG_ON
+        GU_DBUG_EXECUTE("simulate_ist_only_request", {
+           *(reinterpret_cast<uint32_t*>(app_req + offset)) = 0;
+           act->act.buf_len -= sst_len;
+           memmove(app_req     + offset + sizeof(uint32_t),
+                   app_req     + offset + sizeof(uint32_t) + sst_len,
+                   app_req_len - offset - sizeof(uint32_t) - sst_len);
+           sst_len = 0;
+        });
+#endif
+    }
+
+    bool ist_only = true;
+    if (sst_len)
+    {
+        ist_only = false;
+    }
+
     donor_idx = group_select_donor(group,
                                    str_version,
                                    joiner_idx, donor_name,
-                                   &ist_uuid, ist_seqno, desync);
+                                   &ist_uuid, ist_seqno, desync, ist_only);
 
     assert (donor_idx != joiner_idx || desync  || donor_idx < 0);
     assert (donor_idx == joiner_idx || !desync || donor_idx < 0);

--- a/gcs/src/gcs_group.hpp
+++ b/gcs/src/gcs_group.hpp
@@ -251,7 +251,8 @@ gcs_group_find_donor(const gcs_group_t* group,
                      int const str_version,
                      int const joiner_idx,
                      const char* const donor_string, int const donor_len,
-                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno);
+                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno,
+                     const bool ist_only);
 
 extern void
 gcs_group_get_status(gcs_group_t* group, gu::Status& status);

--- a/gcs/src/unit_tests/gcs_group_test.cpp
+++ b/gcs/src/unit_tests/gcs_group_test.cpp
@@ -549,38 +549,38 @@ START_TEST(test_gcs_group_find_donor)
 #define SARGS(s) s, strlen(s)
     //========== sst ==========
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home3"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != -EHOSTDOWN);
 
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home1,home2"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != 1);
 
     nodes[1].status = GCS_NODE_STATE_JOINER;
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home1,home2"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != 2);
     nodes[1].status = GCS_NODE_STATE_SYNCED;
 
     // handle dangling comma.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home3,"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != 0);
 
     // ========== ist ==========
     // by name.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home0,home1,home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 1);
 
     group.quorum.act_id = 1498; // not in safe range.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 2);
 
     group.quorum.act_id = 1497; // in safe range. in segment.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 1);
 
     group.quorum.act_id = 1497; // in safe range. cross segment.
@@ -588,7 +588,7 @@ START_TEST(test_gcs_group_find_donor)
     nodes[1].status = GCS_NODE_STATE_JOINER;
     nodes[2].status = GCS_NODE_STATE_JOINER;
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 5);
     nodes[0].status = GCS_NODE_STATE_SYNCED;
     nodes[1].status = GCS_NODE_STATE_SYNCED;


### PR DESCRIPTION
The node lost connectivity with other nodes in the cluster for some time due to network problems. After this, it need to run IST to synchronize their state with the cluster. However, the IST request has failed.

If we already have large network delays and packet losses, then during IST we can encounter situation when seqno on the donor node has moved forward so much that IST is not possible and we need to run "full" SST request.

To avoid unsuccessful IST attempts, the Galera introduces the concept of "safety gap" - the window for seqno values in which the heuristic algorithm for selecting the donor prefers to switch to SST.

The immediate cause of the PXC-426 error is the inability of the PXC to start new SST request during node operation (using methods other than mysqldump). PXC and Galera written in such way that normally we need a full restart before launching the new SST.

To resolve this contradiction, we need to change the heuristic algorithm that selecting a donor in such way, that it took into account the impossibility of SST. If a joiner node sends a request without SST part, then after applying this patch the donor node must ignore the safety gap window and still tries to execute IST.

It is much better to have a small probability of failure in the IST, than immediately suffer from failure with 100% guarantee (due to heuristics associated with safety gap window). Moreover, if the request contains the SST-related part (not only IST), then we can leave current logic with the additional heuristics related to safety gap window.

However, the algorithm of the donor selection, which implemented in the GCS, contains the potential flaw, and in rare situation it still may choose as a donor such node, where seqno can gone forward before the IST request will be received.

Therefore, since heuristic that selects the donor node does not give us a 100% guarantee that seqno does not moved forward while the new node joining the cluster, and during node operation we have only a requests for the IST without SST part, then we need a way to informing joiner node, that it should prepare to receive SST. This return path also added to the patch code.

Especially we need this signal to notify the user that server unable to perform the SST instead of IST when xtrabackup or rsynch selected as the state transfer method.

In these cases, we need to show the user an explicit message that indicates that we need to perform SST after node restart. However, current version of the server continues to work, even when the synchronization of the node is no longer possible and it cannot continue normal operation in a cluster. Or vice versa, it falls for one of the assertions in the Galera code. This corrected in the patch.

Theoretically, a similar return path also may be activated if the MySQL server does not prepared structures for the SST in the view callback (in the wsrep_view_handler_cb function) after restart of the node. However, in the current version of PXC this should not happen after node restart, because the wsrep_sst_prepare function (which called from wsrep_view_handler_cb) always returns a non-zero value as length of the SST request (node always prepared for both the SST and IST). However, the assertion in the wsrep_view_handler_cb function only checks for the presence of the SST structure, but not its length. Theoretically, when mysqldump method is used this structure can be created with zero length of the SST part.

Therefore, I changed the Galera code to allow restart SST after failing to perform IST - to be protected against failures in the future, when implementation of the wsrep_sst_prepare function may change.

In addition, if the IST request canceled due to an error at the GCS level or by initiative of the server, and if the node remain in the S_JOINING state, then we must return it to the S_CONNECTED state.

PXC part of this patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/198
