### PR TITLE
- #PXC-617: Assertion `GCS_CONN_CLOSED == conn->state' failed in long int gcs_recv(gcs_conn_t*, gcs_action*)

### DIFF
--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1336,9 +1336,12 @@ static void *gcs_recv_thread (void *arg)
     }
     else if (ret < 0)
     {
+        /* We must set connection state to 'closed' to avoid the race
+           condition between gcs_recv_thread() and gcs_recv(), which
+           could lead to assertion in gcs_recv: */
+        gcs_shift_state (conn, GCS_CONN_CLOSED);
         /* In case of error call _close() to release repl_q waiters. */
         (void)_close(conn, false);
-        gcs_shift_state (conn, GCS_CONN_CLOSED);
     }
     gu_info ("RECV thread exiting %d: %s", ret, strerror(-ret));
     return NULL;


### PR DESCRIPTION
Assertion `GCS_CONN_CLOSED == conn->state' failed in long int gcs_recv(gcs_conn_t_, gcs_action_)

This is race condition between the gcs_gcs_recv_thread:

```
   else if (ret < 0)
   {
       /* In case of error call _close() to release repl_q waiters. */
       (void)_close(conn, false);
       gcs_shift_state (conn, GCS_CONN_CLOSED);
   }
   gu_info ("RECV thread exiting %d: %s", ret, strerror(-ret));
```

and the gcs_recv:

```
       case -ENODATA:
       assert (GCS_CONN_CLOSED == conn->state);
       return GCS_CLOSED_ERROR;
```

As we can see, gcs_shift_state (conn, GCS_CONN_CLOSED); called after _close(conn, false), while the second argument of the _close() calls is false (it is important).

The chain of the actions that leads to this error looks like following:

1) _close(..., false) called from the gcs_gcs_recv_thread() function
2) gu_fifo_close() called from _close() and it set ENODATA to fifo error code
3) gu_fifo_close() awakens another thread (which calls gcs_recv function)
4) ENODATA received in the gcs_recv() function
5) But the connection state not shifted yet to 'closed' because another thread (which called _close() function) may be suspended
6) Assertion triggered since state still not shifted to 'closed'
