### PR TITLE
- #PXC-252: [pz@percona.com: Testing Auto Recover]

### DIFF
--- a/common/wsrep_api.h
+++ b/common/wsrep_api.h
@@ -454,6 +454,18 @@ typedef void (*wsrep_synced_cb_t) (void* app_ctx);
 
 
 /*!
+ * @brief a callback to signal application that wsrep provider was
+ * terminated abnormally. In this case, the application can perform
+ * the critical steps to clean its state, for example, it can terminate
+ * the child processes associated with the SST.
+ *
+ * This callback is called after wsrep library was terminated
+ * abnormally using abort() call.
+ */
+typedef void (*wsrep_abort_cb_t) (void);
+
+
+/*!
  * Initialization parameters for wsrep provider.
  */
 struct wsrep_init_args
@@ -485,6 +497,10 @@ struct wsrep_init_args
     /* State Snapshot Transfer callbacks */
     wsrep_sst_donate_cb_t sst_donate_cb;   //!< starting to donate
     wsrep_synced_cb_t     synced_cb;       //!< synced with group
+
+    /* Abnormal termination callback: */
+    wsrep_abort_cb_t      abort_cb;        //!< wsrep provider terminated
+                                           //!< abnormally
 };
 
 

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -158,6 +158,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     unordered_cb_       (args->unordered_cb),
     sst_donate_cb_      (args->sst_donate_cb),
     synced_cb_          (args->synced_cb),
+    abort_cb_           (args->abort_cb),
     sst_donor_          (),
     sst_uuid_           (WSREP_UUID_UNDEFINED),
     sst_seqno_          (WSREP_SEQNO_UNDEFINED),
@@ -197,6 +198,15 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     incoming_mutex_     (),
     wsrep_stats_        ()
 {
+    /*
+      Register the application callback that be called if
+      the wsrep provider will teminated abnormally:
+    */
+    if (abort_cb_)
+    {
+        gu_abort_register_cb(abort_cb_);
+    }
+
     // @todo add guards (and perhaps actions)
     state_.add_transition(Transition(S_CLOSED,  S_DESTROYED));
     state_.add_transition(Transition(S_CLOSED,  S_CONNECTED));
@@ -1471,9 +1481,27 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
         if (st_required && app_wants_st)
         {
             // GCache::Seqno_reset() happens here
-            request_state_transfer (recv_ctx,
-                                    group_uuid, group_seqno, app_req,
-                                    app_req_len);
+            long ret =
+                request_state_transfer (recv_ctx, group_uuid, group_seqno,
+                                        app_req, app_req_len);
+
+            if (ret < 0 || sst_state_ == SST_CANCELED)
+            {
+                // If the IST/SST request was canceled due to error
+                // at the GCS level or if request was canceled by another
+                // thread (by initiative of the server), and if the node
+                // remain in the S_JOINING state, then we must return it
+                // to the S_CONNECTED state (to the original state, which
+                // exist before the request_state_transfer started).
+                // In other words, if state transfer failed then we move
+                // the node back to original state, because joining is
+                // canceled:
+
+                if (state_() == S_JOINING)
+                {
+                    state_.shift_to(S_CONNECTED);
+                }
+            }
         }
         else
         {

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -475,7 +475,7 @@ namespace galera
 
         long send_state_request (const StateRequest* req, const bool unsafe);
 
-        void request_state_transfer (void* recv_ctx,
+        long request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,
                                      wsrep_seqno_t       group_seqno,
                                      const void*         sst_req,
@@ -558,6 +558,7 @@ namespace galera
         wsrep_unordered_cb_t  unordered_cb_;
         wsrep_sst_donate_cb_t sst_donate_cb_;
         wsrep_synced_cb_t     synced_cb_;
+        wsrep_abort_cb_t      abort_cb_;
 
         // SST
         std::string   sst_donor_;

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -703,7 +703,7 @@ ReplicatorSMM::send_state_request (const StateRequest* const req, const bool uns
 }
 
 
-void
+long
 ReplicatorSMM::request_state_transfer (void* recv_ctx,
                                        const wsrep_uuid_t& group_uuid,
                                        wsrep_seqno_t const group_seqno,
@@ -750,10 +750,18 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     // We should not wait for completion of the SST or to handle it
     // results if an error has occurred when sending the request:
 
-    if (send_state_request(req, unsafe) < 0)
+    long ret = send_state_request(req, unsafe);
+    if (ret < 0)
     {
+        // If the state transfer request failed, then
+        // we need to close the IST receiver:
+        if (ist_prepared_)
+        {
+            ist_prepared_ = false;
+            (void)ist_receiver_.finished();
+        }
         delete req;
-        return;
+        return ret;
     }
 
     GU_DBUG_SYNC_WAIT("after_send_state_request");
@@ -786,7 +794,9 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             }
 
             close();
-            return;
+
+            delete req;
+            return -ECANCELED;
         }
         else if (sst_uuid_ != group_uuid)
         {
@@ -856,7 +866,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
             ist_receiver_.ready();
             recv_IST(recv_ctx);
 
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -872,7 +882,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
         }
         else
         {
-            // IST process could already be interrupted if Galera
+            // We must close the IST receiver if the node
             // is in the process of shutting down:
             if (ist_prepared_)
             {
@@ -896,6 +906,7 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
     }
 
     delete req;
+    return 0;
 }
 
 

--- a/galerautils/src/gu_abort.c
+++ b/galerautils/src/gu_abort.c
@@ -15,6 +15,8 @@
 #include <signal.h>       /* for signal()    */
 #include <stdlib.h>       /* for abort()     */
 
+static void (* app_callback) (void) = NULL;
+
 void
 gu_abort (void)
 {
@@ -31,6 +33,18 @@ gu_abort (void)
     gu_info ("Program terminated.");
 #endif
 
+    if (app_callback)
+    {
+        app_callback();
+    }
+
     abort();
 }
 
+/* Register the application callback that be called before exiting: */
+
+void
+gu_abort_register_cb (void (* callback) (void))
+{
+    app_callback = callback;
+}

--- a/galerautils/src/gu_abort.h
+++ b/galerautils/src/gu_abort.h
@@ -18,6 +18,9 @@ extern "C" {
 /* This function is for clean aborts, when we can't gracefully exit otherwise */
 extern void gu_abort() GU_NORETURN;
 
+/* Register the application callback that be called before exiting: */
+extern void gu_abort_register_cb (void (* callback) (void));
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We cannot restart the SST automatically whenever SST fails because the server usually does not have enough information to understand why this was happened. For example, the analysis of the log indicates that the connection has been restored and the 22 error was not fatal:

```
>2014-12-05 17:16:08 2596 [Warning] WSREP: Could not find peer:
>2014-12-05 17:16:08 2596 [Warning] WSREP: 1.0 (nuc3): State transfer to
>-1.-1 (left the group) failed: -22 (Invalid argument)
...
>2014-12-05 17:16:08 2596 [Note] WSREP: Member 1.0 (nuc3) synced with group
```

At the same time log analysis shows that in fact the SST process was completed with another error = 1 ("Operation not permitted"). Perhaps it was a mistake due to insufficient access rights or incorrect password, but not a network error.

If this diagnosis is correct, then restart of the SST did not help us to resolve this problem. If it is wrong, it turns out that at this point we do not have enough information to make the right decision. A simple patch cannot eliminate this (in this case, I think here we need to talk about architecture refining as a separate development task, not just a patch on the product support level).

However, we definitely has a serious problem that we should eliminate. Namely - after detecting a failure due to permissions, the server process is completed improperly, leaving the unfinished thread:

```
Error in my_thread_global_end(): 1 threads didn't exit
>141205 17:16:28 mysqld_safe mysqld from pid file /var/lib/mysql/mysqld.pid
>ended
```

We have already eliminated this error in most scenarios by a previous patches, but I found new possible branches, which similar error arise (for example, it is possible when we repeat the connection attempts after the failure of the SST - although I was not able to reproduce this situation manually or by automatic script since it is rare race condition).

In addition, I found that the failure during the SST, which is diagnosed on the Galera level, leads to the completion of the server using abort() call, but in this case the child processes that have been launched for the SST continues to run after completion of the server.

This makes it impossible to re-start the server before all timeouts expired (in these SST-related processes). Otherwise we failed due to the busy sockets or it leads to other fatal errors due to interference between new and old instances of the SST scripts.

In this patch, I added new checks to safely shutdown the server, for correct processing of a failed attempts to make a new connection and the SST, and for the destruction of all child processes when the server terminated abnormally by initiative of the Galera.

To do this, I needed to add a new callback to wsrep API, because the Galera intercepts the SIGABRT signal. Therefore we cannot intercept abnormal termination of the server process (after it calls abort() function from the Galera side) without expanding the Galera API by adding to it new callback.

PXC part of this patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/229
