### PR TITLE
- #PXC-608: Assertion `node->desync_count > 0' failed in void gcs_nod…e_update_status(gcs_node_t*, const gcs_state_quorum_t*)

### DIFF
--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1026,7 +1026,14 @@ gcs_handle_actions (gcs_conn_t*          conn,
         break;
     case GCS_ACT_SYNC:
         ret = gcs_handle_state_change (conn, &rcvd->act);
-        gcs_become_synced (conn);
+        if (gcs_core_get_state (conn->core) != GCS_NODE_STATE_DONOR)
+        {
+            gcs_become_synced (conn);
+        }
+        else
+        {
+            gcs_become_donor (conn);
+        }
         break;
     default:
         break;

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1399,6 +1399,19 @@ void gcs_core_get_status(gcs_core_t* core, gu::Status& status)
     gu_mutex_unlock(&core->send_lock);
 }
 
+gcs_node_state_t gcs_core_get_state(gcs_core_t* core)
+{
+    gcs_node_state_t state = GCS_NODE_STATE_NON_PRIM;
+    if (gu_mutex_lock(&core->send_lock))
+        gu_throw_fatal << "could not lock mutex";
+    if (core->state < CORE_CLOSED)
+    {
+        state = gcs_group_get_node_state(&core->group);
+    }
+    gu_mutex_unlock(&core->send_lock);
+    return state;
+}
+
 #ifdef GCS_CORE_TESTING
 
 gcs_backend_t*

--- a/gcs/src/gcs_core.hpp
+++ b/gcs/src/gcs_core.hpp
@@ -166,6 +166,8 @@ gcs_core_param_get (gcs_core_t* core, const char* key);
 
 void gcs_core_get_status(gcs_core_t* core, gu::Status& status);
 
+gcs_node_state_t gcs_core_get_state(gcs_core_t* cores);
+
 #ifdef GCS_CORE_TESTING
 
 /* gcs_core_send() interface does not allow enough concurrency control to model

--- a/gcs/src/gcs_group.hpp
+++ b/gcs/src/gcs_group.hpp
@@ -250,4 +250,7 @@ gcs_group_find_donor(const gcs_group_t* group,
 extern void
 gcs_group_get_status(gcs_group_t* group, gu::Status& status);
 
+extern gcs_node_state_t
+gcs_group_get_node_state(gcs_group_t* group);
+
 #endif /* _gcs_group_h_ */

--- a/gcs/src/gcs_node.cpp
+++ b/gcs/src/gcs_node.cpp
@@ -159,6 +159,8 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
                              node_act_id, quorum->act_id);
                 }
                 node->status = GCS_NODE_STATE_PRIM;
+                node->desync_saved = node->desync_count;
+                node->desync_count = 0;
             }
         }
         else {

--- a/gcs/src/gcs_node.hpp
+++ b/gcs/src/gcs_node.hpp
@@ -43,6 +43,8 @@ struct gcs_node
     int              repl_proto_ver;
     int              appl_proto_ver;
     int              desync_count;
+    int              desync_saved; // Value of the desync_count, which
+                                   // is saved before the IST.
     gcs_node_state_t status;       // node status
     gcs_segment_t    segment;
     bool             count_last_applied; // should it be counted


### PR DESCRIPTION
This error occurs because although disconnection node from the cluster involves stop of replication, closing of all client connections and consequently the cancellation of all transactions (which are tied to client connections), but the desynchronization counter associated with the current node, as well as the last state of the node, which is stored in the prim_state field of the gcs_group_t structure, are not cleared even after disconnecting the node from the cluster.

PXC part of this patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/249
