### PR TITLE
- #PXC-665: SST donor node has status "JOINED" after successful resync

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1202,6 +1202,8 @@ galera::ReplicatorSMM::sst_sent(const wsrep_gtid_t& state_id, int const rcode)
     assert (rcode == 0 || state_id.seqno == WSREP_SEQNO_UNDEFINED);
     assert (rcode != 0 || state_id.seqno >= 0);
 
+    GU_DBUG_SYNC_WAIT("sst_sent");
+
     if (state_() != S_DONOR)
     {
         log_error << "sst sent called when not SST donor, state " << state_();

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -773,9 +773,15 @@ gcs_group_handle_join_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
                 }
             }
             else {
-                gu_info ("%d.%d (%s): State transfer %s %d.%d (%s) complete.",
-                         sender_idx, sender->segment, sender->name, st_dir,
-                         peer_idx, peer ? peer->segment : -1, peer_name);
+                if (GCS_NODE_STATE_JOINED == sender->status) {
+                    gu_info ("%d.%d (%s): State transfer %s %d.%d (%s) complete.",
+                             sender_idx, sender->segment, sender->name, st_dir,
+                             peer_idx, peer ? peer->segment : -1, peer_name);
+                }
+                else {
+                    assert(sender->desync_count > 0);
+                    return 0; // don't deliver up
+                }
             }
         }
     }


### PR DESCRIPTION
Operations that use the global lock (such as FLUSH TABLES FOR READ LOCK) and DDL operations that are protected via the RSU can be performed during SST. In this case, they come into interference with the SST process, which leads to a variety of bugs, including hang or crash of the donor node after SST donation. Alternatively, the SST donor node stays in the "JOINED" status, even after the completion of the SST.

This patch solves the problem with the incorrect classification of the "JOIN" message (which is generated as response to the wsrep->resync() call) at the GCS layer. Improper handling of the JOIN message leads to ignoring of the subsequent SYNC message and generates the above-described problems.

Pausing of the RSU operations during the SST will be solved as a separate issue in another patch.

PXC part of this patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/259
