### PR TITLE
- #PXC-608: Assertion `node->desync_count > 0' failed in void gcs_node_update_status(gcs_node_t*, const gcs_state_quorum_t*)

### DIFF
--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -432,6 +432,13 @@ gcs_group_handle_comp_msg (gcs_group_t* group, const gcs_comp_msg_t* comp)
         gu_info ("Received self-leave message.");
         assert (0 == new_nodes_num);
         assert (!prim_comp);
+        /* Reset node desynchronization counter and the saved state
+           when node was disconnected from the cluster: */
+        if (group->my_idx >= 0 && group->nodes[group->my_idx].desync_count)
+        {
+            group->prim_state = GCS_NODE_STATE_JOINED;
+            group->nodes[group->my_idx].desync_count = 0;
+        }
     }
 
     if (prim_comp) {


### PR DESCRIPTION
This error occurs because although disconnection node from the cluster involves stop of replication, closing of all client connections and consequently the cancellation of all transactions (which are tied to client connections), but the desynchronization counter associated with the current node, as well as the last state of the node, which is stored in the prim_state field of the gcs_group_t structure, are not cleared even after disconnecting the node from the cluster.

PXC part of this patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/261
