### PR TITLE
- #PXC-703: Unable to build Galera on several systems (using Jenkins)

### DIFF
--- a/asio/asio/detail/impl/epoll_reactor.ipp
+++ b/asio/asio/detail/impl/epoll_reactor.ipp
@@ -265,6 +265,24 @@ void epoll_reactor::run(bool block, op_queue<operation>& ops)
 #if defined(ASIO_HAS_TIMERFD)
     else if (ptr == &timer_fd_)
     {
+      // We should read an 8-byte timeout expiration counter (using
+      // the "timerfd" descriptor) every time when the EPOLLIN event
+      // occurs. Otherwise, the timer stops to notifying the application
+      // about new events, and all activity associated with this timer
+      // will be frozen on some systems, or vice versa, we get an infinite
+      // loop of notifications because of the constant readiness to read
+      // the new data:
+
+      if (events[i].events & EPOLLIN)
+      {
+        // If timeout was expired, we should read the expiration counter:
+        uint64_t count;
+        if (read(timer_fd_, &count, sizeof(count)))
+        {
+          // Just to ignore return value of the read() function
+          // without compiler warning...
+        }
+      }
       check_timers = true;
     }
 #endif // defined(ASIO_HAS_TIMERFD)


### PR DESCRIPTION
Recently we unable to build Galera on several systems (for example, using the Jenkins):
- debian-wheezy-x64 (https://wiki.debian.org/DebianWheezy);
- ubuntu-wily-x64 (http://old-releases.ubuntu.com/releases/15.10/);
- debian-jessie-x64 with AddressSanitizer (https://www.debian.org/releases/jessie/ + https://en.wikipedia.org/wiki/AddressSanitizer);
- centos6-32 (https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.8);

The following error messages often appears in many configurations:

```
07:03:31 94%: Checks: 79, Failures: 0, Errors: 4
07:03:31 gcomm/test/check_util.cpp:170:E:test_protonet:test_protonet:0: (after this point) Test timeout expired
07:03:31 gcomm/test/check_gmcast.cpp:240:E:test_gmcast_w_user_messages:test_gmcast_w_user_messages:0: (after this point) Test timeout expired
07:03:31 gcomm/test/check_gmcast.cpp:294:E:test_gmcast_forget:test_gmcast_forget:0: (after this point) Test timeout expired
07:03:31 gcomm/test/check_pc.cpp:1427:E:test_pc_transport:test_pc_transport:0: (after this point) Test timeout expired
07:03:31 scons: *** [gcomm/test/gcomm_check.passed] Error 1
```

This error occurs in the ASIO C++ library because the Linux kernel requires the application to read an 8-byte timeout expiration counter (using the "timerfd" descriptor) every time when the EPOLLIN event occurs. Otherwise, the timer stops to notifying the application about new events, and all activity associated with this timer will be frozen on some systems, or vice versa, we get an infinite loop of notifications because of the constant readiness to read the new data.

But ASIO library does not read the data using the "timerfd" descriptor after returning from the epoll_wait().

To fix this problem, we should read the 8-byte expiration counter from the "timerfd" descriptor every time, when the EPOLLIN event occurs.
