### PR TITLE
- PXC#252/PXC#426: Race condition in IST

### DIFF
--- a/common/wsrep_api.h
+++ b/common/wsrep_api.h
@@ -454,6 +454,18 @@ typedef void (*wsrep_synced_cb_t) (void* app_ctx);
 
 
 /*!
+ * @brief a callback to signal application that wsrep provider was
+ * terminated abnormally. In this case, the application can perform
+ * the critical steps to clean its state, for example, it can terminate
+ * the child processes associated with the SST.
+ *
+ * This callback is called after wsrep library was terminated
+ * abnormally using abort() call.
+ */
+typedef void (*wsrep_abort_cb_t) (void);
+
+
+/*!
  * Initialization parameters for wsrep provider.
  */
 struct wsrep_init_args
@@ -485,6 +497,10 @@ struct wsrep_init_args
     /* State Snapshot Transfer callbacks */
     wsrep_sst_donate_cb_t sst_donate_cb;   //!< starting to donate
     wsrep_synced_cb_t     synced_cb;       //!< synced with group
+
+    /* Abnormal termination callback: */
+    wsrep_abort_cb_t      abort_cb;        //!< wsrep provider terminated
+                                           //!< abnormally
 };
 
 

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -158,6 +158,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     unordered_cb_       (args->unordered_cb),
     sst_donate_cb_      (args->sst_donate_cb),
     synced_cb_          (args->synced_cb),
+    abort_cb_           (args->abort_cb),
     sst_donor_          (),
     sst_uuid_           (WSREP_UUID_UNDEFINED),
     sst_seqno_          (WSREP_SEQNO_UNDEFINED),
@@ -197,6 +198,15 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     incoming_mutex_     (),
     wsrep_stats_        ()
 {
+    /*
+      Register the application callback that should be called
+      if the wsrep provider will teminated abnormally:
+    */
+    if (abort_cb_)
+    {
+        gu_abort_register_cb(abort_cb_);
+    }
+
     // @todo add guards (and perhaps actions)
     state_.add_transition(Transition(S_CLOSED,  S_DESTROYED));
     state_.add_transition(Transition(S_CLOSED,  S_CONNECTED));
@@ -1471,9 +1481,28 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
         if (st_required && app_wants_st)
         {
             // GCache::Seqno_reset() happens here
-            request_state_transfer (recv_ctx,
-                                    group_uuid, group_seqno, app_req,
-                                    app_req_len);
+            long ret =
+                request_state_transfer (recv_ctx,
+                                        group_uuid, group_seqno,
+                                        app_req, app_req_len);
+
+            if (ret < 0 || sst_state_ == SST_CANCELED)
+            {
+                // If the IST/SST request was canceled due to error
+                // at the GCS level or if request was canceled by another
+                // thread (by initiative of the server), and if the node
+                // remain in the S_JOINING state, then we must return it
+                // to the S_CONNECTED state (to the original state, which
+                // exist before the request_state_transfer started).
+                // In other words, if state transfer failed, then we
+                // need to move node back to the original state, because
+                // joining was canceled:
+
+                if (state_() == S_JOINING)
+                {
+                    state_.shift_to(S_CONNECTED);
+                }
+            }
         }
         else
         {
@@ -1514,8 +1543,13 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
             st_.set(state_uuid_, WSREP_SEQNO_UNDEFINED);
         }
 
-        if (state_() == S_JOINING && sst_state_ != SST_NONE
-                                  && sst_state_ != SST_CANCELED)
+        // We should not try to joining the cluster at the GCS level,
+        // if the node is not in the S_JOINING state, or if we did not
+        // sent the IST/SST request, or if it is failed. In other words,
+        // any state other than SST_WAIT (f.e. SST_NONE or SST_CANCELED)
+        // not require us to sending the JOIN message at the GCS level:
+
+        if (sst_state_ == SST_WAIT && state_() == S_JOINING)
         {
             /* There are two reasons we can be here:
              * 1) we just got state transfer in request_state_transfer() above;

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -475,7 +475,7 @@ namespace galera
 
         long send_state_request (const StateRequest* req, const bool unsafe);
 
-        void request_state_transfer (void* recv_ctx,
+        long request_state_transfer (void* recv_ctx,
                                      const wsrep_uuid_t& group_uuid,
                                      wsrep_seqno_t       group_seqno,
                                      const void*         sst_req,
@@ -558,6 +558,7 @@ namespace galera
         wsrep_unordered_cb_t  unordered_cb_;
         wsrep_sst_donate_cb_t sst_donate_cb_;
         wsrep_synced_cb_t     synced_cb_;
+        wsrep_abort_cb_t      abort_cb_;
 
         // SST
         std::string   sst_donor_;

--- a/galerautils/src/gu_abort.c
+++ b/galerautils/src/gu_abort.c
@@ -15,6 +15,8 @@
 #include <signal.h>       /* for signal()    */
 #include <stdlib.h>       /* for abort()     */
 
+static void (* app_callback) (void) = NULL;
+
 void
 gu_abort (void)
 {
@@ -31,6 +33,18 @@ gu_abort (void)
     gu_info ("Program terminated.");
 #endif
 
+    if (app_callback)
+    {
+        app_callback();
+    }
+
     abort();
 }
 
+/* Register the application callback that be called before exiting: */
+
+void
+gu_abort_register_cb (void (* callback) (void))
+{
+    app_callback = callback;
+}

--- a/galerautils/src/gu_abort.h
+++ b/galerautils/src/gu_abort.h
@@ -18,6 +18,9 @@ extern "C" {
 /* This function is for clean aborts, when we can't gracefully exit otherwise */
 extern void gu_abort() GU_NORETURN;
 
+/* Register the application callback that be called before exiting: */
+extern void gu_abort_register_cb (void (* callback) (void));
+
 #ifdef __cplusplus
 }
 #endif

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -741,6 +741,25 @@ gcs_group_handle_join_msg  (gcs_group_t* group, const gcs_recv_msg_t* msg)
 
             if (from_donor && peer_idx == group->my_idx &&
                 GCS_NODE_STATE_JOINER == group->nodes[peer_idx].status) {
+
+                // If there is an ENODATA error code, then it is indication
+                // that state on the donor node was moved forward too much
+                // and we need to initiate a full SST instead of IST.
+                // We should not treat this condition as a fatal error
+                // (decision on this matter should take higher levels,
+                // for example, Replicator or the server):
+
+                if (seqno == -ENODATA)
+                {
+                    gu_fatal ("State transfer request failed unrecoverably "
+                              "because the donor seqno had gone forward "
+                              "during IST, but SST request was not prepared "
+                              "from our side due to selected state transfer "
+                              "method (which do not supports SST during "
+                              "node operation). Restart required.");
+                    return -ENOTRECOVERABLE;
+                }
+
                 // this node will be waiting for SST forever. If it has only
                 // one recv thread there is no (generic) way to wake it up.
                 gu_fatal ("Will never receive state. Need to abort.");
@@ -1144,7 +1163,8 @@ group_find_ist_donor (const gcs_group_t* const group,
                       int joiner_idx,
                       const char* str, int str_len,
                       gcs_seqno_t ist_seqno,
-                      gcs_node_state_t status)
+                      gcs_node_state_t status,
+                      const bool ist_only)
 {
     int idx = -1;
 
@@ -1158,7 +1178,11 @@ group_find_ist_donor (const gcs_group_t* const group,
     gcs_seqno_t const max_cached_range = conf_seqno - lowest_cached_seqno;
     gcs_seqno_t safety_gap = max_cached_range >> 7; /* 1.0 / 128 ~= 0.008 */
     safety_gap = safety_gap < (1 << 20) ? safety_gap : (1 << 20); /* Be sensible and don't reserve more than 1M */
-    gcs_seqno_t safe_ist_seqno = lowest_cached_seqno + safety_gap;
+
+    // We should ignore safety_gap heuristic if the request contains
+    // only a IST part, since otherwise we cannot fulfill the request:
+
+    gcs_seqno_t safe_ist_seqno = lowest_cached_seqno + (ist_only ? 0 : safety_gap);
 
     gu_debug("ist_seqno[%lld], lowest_cached_seqno[%lld],"
              "conf_seqno[%lld], safe_ist_seqno[%lld]",
@@ -1189,7 +1213,8 @@ gcs_group_find_donor(const gcs_group_t* group,
                      int const str_version,
                      int const joiner_idx,
                      const char* const donor_string, int const donor_len,
-                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno)
+                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno,
+                     const bool ist_only)
 {
     static gcs_node_state_t const min_donor_state = GCS_NODE_STATE_SYNCED;
 
@@ -1205,7 +1230,8 @@ gcs_group_find_donor(const gcs_group_t* group,
                                          joiner_idx,
                                          donor_string, donor_len,
                                          ist_seqno,
-                                         min_donor_state);
+                                         min_donor_state,
+                                         ist_only);
     }
     if (donor_idx < 0)
     {
@@ -1235,7 +1261,8 @@ group_select_donor (gcs_group_t* group,
                     int const joiner_idx,
                     const char* const donor_string,
                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno,
-                    bool const desync)
+                    const bool desync,
+                    const bool ist_only)
 {
     static gcs_node_state_t const min_donor_state = GCS_NODE_STATE_SYNCED;
     int  donor_idx;
@@ -1261,7 +1288,8 @@ group_select_donor (gcs_group_t* group,
                                          str_version,
                                          joiner_idx,
                                          donor_string, donor_len,
-                                         ist_uuid, ist_seqno);
+                                         ist_uuid, ist_seqno,
+                                         ist_only);
     }
 
     if (donor_idx >= 0) {
@@ -1391,10 +1419,54 @@ gcs_group_handle_state_request (gcs_group_t*         group,
         }
     }
 
+    // We need to perform a partial analysis of the application
+    // request to find out that it contains the SST part (not just IST):
+
+    int app_req_len = act->act.buf_len - (donor_name_len + 1);
+    char * app_req =
+        reinterpret_cast<char*>(const_cast<void*>(act->act.buf)) +
+        (donor_name_len + 1);
+
+    // Requests of the "zero" version contain only the SST part.
+    // They can be distinguished from the first version of the requests
+    // by the lack of the "magic" prefix:
+
+    int sst_len = app_req_len;
+    int magic_len = strlen("STRv1");
+
+    if (app_req_len > magic_len && !strncmp(app_req, "STRv1", magic_len))
+    {
+        // Request of the first version contain an explicit length
+        // of the SST part:
+
+        int offset = magic_len + 1;
+        sst_len = gtohl(*(reinterpret_cast<uint32_t*>(app_req + offset)));
+
+        // To facilitate debugging, we may need involuntary stimulation
+        // of the lack of SST part in the request:
+
+#ifdef GU_DBUG_ON
+        GU_DBUG_EXECUTE("simulate_ist_only_request", {
+           *(reinterpret_cast<uint32_t*>(app_req + offset)) = 0;
+           act->act.buf_len -= sst_len;
+           memmove(app_req     + offset + sizeof(uint32_t),
+                   app_req     + offset + sizeof(uint32_t) + sst_len,
+                   app_req_len - offset - sizeof(uint32_t) - sst_len);
+           sst_len = 0;
+        });
+#endif
+    }
+
+    bool ist_only = true;
+    if (sst_len)
+    {
+        ist_only = false;
+    }
+
     donor_idx = group_select_donor(group,
                                    str_version,
                                    joiner_idx, donor_name,
-                                   &ist_uuid, ist_seqno, desync);
+                                   &ist_uuid, ist_seqno, desync, ist_only);
 
     assert (donor_idx != joiner_idx || desync  || donor_idx < 0);
     assert (donor_idx == joiner_idx || !desync || donor_idx < 0);

--- a/gcs/src/gcs_group.hpp
+++ b/gcs/src/gcs_group.hpp
@@ -245,7 +245,8 @@ gcs_group_find_donor(const gcs_group_t* group,
                      int const str_version,
                      int const joiner_idx,
                      const char* const donor_string, int const donor_len,
-                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno);
+                     const gu_uuid_t* ist_uuid, gcs_seqno_t ist_seqno,
+                     const bool ist_only);
 
 extern void
 gcs_group_get_status(gcs_group_t* group, gu::Status& status);

--- a/gcs/src/unit_tests/gcs_group_test.cpp
+++ b/gcs/src/unit_tests/gcs_group_test.cpp
@@ -549,38 +549,38 @@ START_TEST(test_gcs_group_find_donor)
 #define SARGS(s) s, strlen(s)
     //========== sst ==========
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home3"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != -EHOSTDOWN);
 
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home1,home2"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != 1);
 
     nodes[1].status = GCS_NODE_STATE_JOINER;
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home1,home2"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != 2);
     nodes[1].status = GCS_NODE_STATE_SYNCED;
 
     // handle dangling comma.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home3,"),
-                                 &empty_uuid, GCS_SEQNO_ILL);
+                                 &empty_uuid, GCS_SEQNO_ILL, false);
     fail_if(donor != 0);
 
     // ========== ist ==========
     // by name.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home0,home1,home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 1);
 
     group.quorum.act_id = 1498; // not in safe range.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 2);
 
     group.quorum.act_id = 1497; // in safe range. in segment.
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 1);
 
     group.quorum.act_id = 1497; // in safe range. cross segment.
@@ -588,7 +588,7 @@ START_TEST(test_gcs_group_find_donor)
     nodes[1].status = GCS_NODE_STATE_JOINER;
     nodes[2].status = GCS_NODE_STATE_JOINER;
     donor = gcs_group_find_donor(&group, sv, joiner, SARGS("home2"),
-                                 group_uuid, ist_seqno);
+                                 group_uuid, ist_seqno, false);
     fail_if(donor != 5);
     nodes[0].status = GCS_NODE_STATE_SYNCED;
     nodes[1].status = GCS_NODE_STATE_SYNCED;


### PR DESCRIPTION
  (patch from Julius)

  PART I: PXC#426: Race condition during IST

---

  The node lost connectivity with other nodes in the cluster for some time due
  to network problems. After this, it need to run IST to synchronize the state
  with the cluster. However, the IST request still fails.

  (Probable cause: donor has made progress and no more holds a needed
   seqno needed for IST to complete successfully)

  Galera has concept of safety_gap to handle this problem (though not 100%
  fool-proof) and if the check fails then it suggest switching to SST.
  If server is configured to use rsync or XB method online SST during
  node operation is not possible.

  It is important that if server is forced to switch to SST
  and SST is not possible then node indicate so and shutdown properly.
  (State of node should be restored too).

  PART II: PXC#252: SST operation failure should ensure cleanup

---

  If the SST fails for the reason mentioned above the node should successully
  clean the resources before shutdown.

  PART III: Changes in the wsrep API (continuation of the #PXC-252):

---

  In addition, I found that the failure during the SST, which is diagnosed on
  the Galera level, leads to the completion of the server using abort() call,
  but in this case the child processes that have been launched for the SST
  continues to run after completion of the server.

  This makes it impossible to re-start the server before all timeouts expired
  (in these SST-related processes). Otherwise we failed due to the busy sockets
  or it leads to other fatal errors due to interference between new and old
  instances of the SST scripts.

  In this patch, I added new checks to safely shutdown the server, for correct
  processing of a failed attempts to make a new connection and the SST, and for
  the destruction of all child processes when the server terminated abnormally
  by initiative of the Galera.

  To do this, I needed to add a new callback to wsrep API, because the Galera
  intercepts the SIGABRT signal. Therefore we cannot intercept abnormal
  termination of the server process (after it calls abort() function from the
  Galera side) without expanding the Galera API by adding to it new callback.
