### PR TITLE
- #PXC-666: DDL operations protected via RSU can change the database during SST

### DIFF
--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -487,6 +487,12 @@ namespace galera
         /* local state seqno for internal use (macro mock up) */
         wsrep_seqno_t STATE_SEQNO(void) { return apply_monitor_.last_left(); }
 
+        /* Desynchronization control functions: */
+
+        void desync_wait ();
+        void desync_on ();
+        void desync_off ();
+
         class InitLib /* Library initialization routines */
         {
         public:
@@ -559,6 +565,17 @@ namespace galera
         wsrep_sst_donate_cb_t sst_donate_cb_;
         wsrep_synced_cb_t     synced_cb_;
         wsrep_abort_cb_t      abort_cb_;
+
+        // Desynchronization control variables:
+        int       desync_; // 0 = synched,
+                           // 1 = desynched,
+                           // 2 = wait for resync.
+        gu::Mutex desync_mutex_;
+        gu::Cond  desync_cond_;
+
+        // Desynchronization-related state transition actions:
+        StateAction desync_act_on_;
+        StateAction desync_act_off_;
 
         // SST
         std::string   sst_donor_;


### PR DESCRIPTION
Currently DDL operations that are protected via the RSU can
be performed during SST. Thus, the database can be changed
during execution of the SST process.

Therefore, the SST process may transfer to another node
the incorrect snapshot. To avoid this problem, we should
pause new desynchronization requests (wsrep->desync() API
calls), which are intiated by the RSU, until completion
of the SST.

Unfortunately there are many options for implicit
completion of the SST, and Replicator layer does not
always receive clear notification about it. But it
always gets some kind of message, which changes
its state. Therefore, to track any exit from the
desynchronization mode, which was established for
the SST, and to continue execution of the thread
that wants to make a new desynchronization on behalf
of the RSU, I used the mechanism of action linked
to the finite state machine transitions, which is
already implemented in the Galera (but currently
not used in practice for other purposes).