### PR TITLE
Fix PXC-690: Display Flow control interval as a status variable

### DIFF
--- a/galera/src/replicator_smm_stats.cpp
+++ b/galera/src/replicator_smm_stats.cpp
@@ -101,6 +101,7 @@ typedef enum status_vars
     STATS_FC_PAUSED_AVG,
     STATS_FC_SENT,
     STATS_FC_RECEIVED,
+    STATS_FC_INTERVAL,
     STATS_CERT_DEPS_DISTANCE,
     STATS_APPLY_OOOE,
     STATS_APPLY_OOOL,
@@ -148,6 +149,7 @@ static const struct wsrep_stats_var wsrep_stats[STATS_MAX + 1] =
     { "flow_control_paused",      WSREP_VAR_DOUBLE, { 0 }  },
     { "flow_control_sent",        WSREP_VAR_INT64,  { 0 }  },
     { "flow_control_recv",        WSREP_VAR_INT64,  { 0 }  },
+    { "flow_control_interval",    WSREP_VAR_STRING, { 0 }  },
     { "cert_deps_distance",       WSREP_VAR_DOUBLE, { 0 }  },
     { "apply_oooe",               WSREP_VAR_DOUBLE, { 0 }  },
     { "apply_oool",               WSREP_VAR_DOUBLE, { 0 }  },
@@ -206,6 +208,9 @@ galera::ReplicatorSMM::stats_get()
     gcs_.get_stats (&stats);
 
     int64_t seqno_min = gcache_.seqno_min();
+    char    interval[64];
+    snprintf(interval, sizeof(interval), "[ %ld, %ld ]",
+             stats.fc_lower_limit, stats.fc_upper_limit);
 
     sv[STATS_LOCAL_SEND_QUEUE    ].value._int64  = stats.send_q_len;
     sv[STATS_LOCAL_SEND_QUEUE_MAX].value._int64  = stats.send_q_len_max;
@@ -221,6 +226,8 @@ galera::ReplicatorSMM::stats_get()
     sv[STATS_FC_PAUSED_AVG       ].value._double = stats.fc_paused_avg;
     sv[STATS_FC_SENT             ].value._int64  = stats.fc_sent;
     sv[STATS_FC_RECEIVED         ].value._int64  = stats.fc_received;
+    sv[STATS_FC_INTERVAL         ].value._string = interval;
+
 
 
     double avg_cert_interval(0);

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -2001,6 +2001,9 @@ gcs_get_stats (gcs_conn_t* conn, struct gcs_stats* stats)
 
     stats->fc_sent     = conn->stats_fc_sent;
     stats->fc_received = conn->stats_fc_received;
+
+    stats->fc_lower_limit = conn->lower_limit;
+    stats->fc_upper_limit = conn->upper_limit;
 }
 
 void

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -440,6 +440,8 @@ struct gcs_stats
     int       send_q_len;     //! current send queue length
     int       send_q_len_max; //! maximum send queue length
     int       send_q_len_min; //! minimum send queue length
+    long      fc_lower_limit; //! Flow-control interval lower limit
+    long      fc_upper_limit; //! Flow-control interval upper limit
     gcs_backend_stats_t backend_stats; //! backend stats.
 };
 

--- a/gcs/src/gcs_params.cpp
+++ b/gcs/src/gcs_params.cpp
@@ -20,7 +20,7 @@ const char* const GCS_PARAMS_RECV_Q_HARD_LIMIT = "gcs.recv_q_hard_limit";
 const char* const GCS_PARAMS_RECV_Q_SOFT_LIMIT = "gcs.recv_q_soft_limit";
 const char* const GCS_PARAMS_MAX_THROTTLE      = "gcs.max_throttle";
 
-static const char* const GCS_PARAMS_FC_FACTOR_DEFAULT         = "1.0";
+static const char* const GCS_PARAMS_FC_FACTOR_DEFAULT         = "1";
 static const char* const GCS_PARAMS_FC_LIMIT_DEFAULT          = "16";
 static const char* const GCS_PARAMS_FC_MASTER_SLAVE_DEFAULT   = "no";
 static const char* const GCS_PARAMS_FC_DEBUG_DEFAULT          = "0";
@@ -57,7 +57,6 @@ gcs_params_register(gu_config_t* conf)
                           GCS_PARAMS_RECV_Q_SOFT_LIMIT_DEFAULT);
     ret |= gu_config_add (conf, GCS_PARAMS_MAX_THROTTLE,
                           GCS_PARAMS_MAX_THROTTLE_DEFAULT);
-
     return ret;
 }
 


### PR DESCRIPTION
Issue:
The values for the flow control interval can only be seen in the
logs when the values are changed.

Solution:
Add a status variable ('wsrep_flow_control_interval') to expose
the lower and upper limits of the flow control mechanism.
This is a read-only variable.