### PR TITLE
- PXC#672: repl.commit_order = 2 (LOCAL_OOOC) causes cluster to stall

### DIFF
--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -356,7 +356,7 @@ namespace galera
                 case OOOC:
                     return true;
                 case LOCAL_OOOC:
-                    return trx_.is_local();
+                    if (trx_.is_local()) { return true; }
                     // in case of remote trx fall through
                 case NO_OOOC:
                     return (last_left + 1 == trx_.global_seqno());


### PR DESCRIPTION
  repl.commit_order = 2 (LOCAL_OOOC) suggest out-of-order commit for
  local transaction. This is achieved by checking if the transaction
  is local and skipping the commit ordering if found to be local.

  Logic intend to use the OOOC condition if transaction is remote
  but due to faulty condition check, it always returned false
  if transaction is remote causing cluster to stall.