### PR TITLE
PXC-594 PXC-608: Assertion `sender->count_last_applied' failed in gcs_group_handle_join_msg(gcs_group_t*, const gcs_recv_msg_t*)

### DIFF
--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1399,6 +1399,12 @@ void gcs_core_get_status(gcs_core_t* core, gu::Status& status)
     gu_mutex_unlock(&core->send_lock);
 }
 
+int
+gcs_core_get_desync (gcs_core_t* core)
+{
+    return gcs_group_get_desync(&core->group);
+}
+
 #ifdef GCS_CORE_TESTING
 
 gcs_backend_t*

--- a/gcs/src/gcs_core.hpp
+++ b/gcs/src/gcs_core.hpp
@@ -164,7 +164,11 @@ gcs_core_param_set (gcs_core_t* core, const char* key, const char* value);
 extern const char*
 gcs_core_param_get (gcs_core_t* core, const char* key);
 
-void gcs_core_get_status(gcs_core_t* core, gu::Status& status);
+extern void
+gcs_core_get_status(gcs_core_t* core, gu::Status& status);
+
+extern int
+gcs_core_get_desync (gcs_core_t* core);
 
 #ifdef GCS_CORE_TESTING
 

--- a/gcs/src/gcs_group.hpp
+++ b/gcs/src/gcs_group.hpp
@@ -251,4 +251,7 @@ gcs_group_find_donor(const gcs_group_t* group,
 extern void
 gcs_group_get_status(gcs_group_t* group, gu::Status& status);
 
+extern int
+gcs_group_get_desync (gcs_group_t* group);
+
 #endif /* _gcs_group_h_ */

--- a/gcs/src/gcs_node.cpp
+++ b/gcs/src/gcs_node.cpp
@@ -159,6 +159,12 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
                              node_act_id, quorum->act_id);
                 }
                 node->status = GCS_NODE_STATE_PRIM;
+                // If currently node is desynchronized, then after IST
+                // we should return it to its original state:
+                if (node->desync_count) {
+                    node->saved_desync = node->desync_count;
+                    node->desync_count = 0;
+                }
             }
         }
         else {

--- a/gcs/src/gcs_node.hpp
+++ b/gcs/src/gcs_node.hpp
@@ -42,7 +42,9 @@ struct gcs_node
     int              gcs_proto_ver;// supported protocol versions
     int              repl_proto_ver;
     int              appl_proto_ver;
-    int              desync_count;
+    int              desync_count; // desynchronization counter
+    int              saved_desync; // saved desynchronization counter 
+                                   // (to use after IST)
     gcs_node_state_t status;       // node status
     gcs_segment_t    segment;
     bool             count_last_applied; // should it be counted


### PR DESCRIPTION
This patch fixes two bugs:

PART I, PXC-594:
----------------

Assertion `sender->count_last_applied' failed in the
gcs_group_handle_join_msg() function.

This error stems from the fact that we have added
a direct transition from JOINED to DONOR state bypassing
SYNCED state, but does not take into account that in this
case the count_last_applied flag is lost. It is necessary
to change it in such a direct transition.

PART II, PXC-608:
-----------------

Assertion `node->desync_count > 0' failed in the
the gcs_node_update_status() function.

This error occurs because although disconnection node
from the cluster involves stop of replication, closing
of all client connections and consequently the cancellation
of all transactions (which are tied to client connections),
but the desynchronization counter associated with the current
node, as well as the last state of the node, which is stored
in the prim_state field of the gcs_group_t structure, are not
cleared even after disconnecting the node from the cluster.

Related PXC patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/360