### PR TITLE
- #PXC-330: Possible data corruption on SST with innodb_flush_method=O_DIRECT

### DIFF
--- a/galera/src/mapped_buffer.cpp
+++ b/galera/src/mapped_buffer.cpp
@@ -103,6 +103,21 @@ void galera::MappedBuffer::reserve(size_t sz)
                 clear();
                 gu_throw_error(dummy_errno) << "mmap() failed";
             }
+#if defined(MADV_DONTFORK)
+            if (posix_madvise(tmp, sz, MADV_DONTFORK))
+            {
+                int const err(errno);
+                log_warn << "Failed to set MADV_DONTFORK on allocated "
+                         << "buffer: " << err << " (" << strerror(err) << ")";
+            }
+#elif defined(__FreeBSD__)
+            if (minherit(tmp, sz, INHERIT_NONE))
+            {
+                int const err(errno);
+                log_warn << "Failed to set INHERIT_NONE on allocated "
+                         << "buffer: " << err << " (" << strerror(err) << ")";
+            }
+#endif
             copy(buf_, buf_ + buf_size_, tmp);
             free(buf_);
             buf_ = tmp;
@@ -126,6 +141,21 @@ void galera::MappedBuffer::reserve(size_t sz)
                 clear();
                 gu_throw_error(dummy_errno) << "mmap() failed";
             }
+#if defined(MADV_DONTFORK)
+            if (posix_madvise(tmp, sz, MADV_DONTFORK))
+            {
+                int const err(errno);
+                log_warn << "Failed to set MADV_DONTFORK on allocated "
+                         << "buffer: " << err << " (" << strerror(err) << ")";
+            }
+#elif defined(__FreeBSD__)
+            if (minherit(tmp, sz, INHERIT_NONE))
+            {
+                int const err(errno);
+                log_warn << "Failed to set INHERIT_NONE on allocated "
+                         << "buffer: " << err << " (" << strerror(err) << ")";
+            }
+#endif
             buf_ = tmp;
         }
     }

--- a/galerautils/src/gu_mmap.cpp
+++ b/galerautils/src/gu_mmap.cpp
@@ -49,8 +49,14 @@ namespace gu
             log_warn << "Failed to set MADV_DONTFORK on " << fd.name()
                      << ": " << err << " (" << strerror(err) << ")";
         }
+#elif defined(__FreeBSD__)
+        if (minherit(ptr, size, INHERIT_NONE))
+        {
+            int const err(errno);
+            log_warn << "Failed to set INHERIT_NONE on " << fd.name()
+                     << ": " << err << " (" << strerror(err) << ")";
+        }
 #endif
-
         /* benefits are questionable */
         if (sequential && posix_madvise (ptr, size, MADV_SEQUENTIAL))
         {


### PR DESCRIPTION
Using O_DIRECT I/Os in conjunction with mmap() can lead to problems,
if the memory buffer is a private mapping. Quoting the Linux man
page for open(2):

```
O_DIRECT I/Os should never be run concurrently with the fork(2) system call,
if the memory buffer is a private mapping (i.e., any mapping created with
the mmap(2) MAP_PRIVATE flag; this includes memory allocated on the heap
and statically allocated buffers). Any such I/Os, whether submitted via
an asynchronous I/O interface or from another thread in the process,
should be completed before fork(2) is called. Failure to do so can result
in data corruption and undefined behavior in parent and child processes.
This restriction does not apply when the memory buffer for the O_DIRECT
I/Os was created using shmat(2) or mmap(2) with the MAP_SHARED flag.
Nor does this restriction apply when the memory buffer has been advised
as MADV_DONTFORK with madvise(2), ensuring that it will not be available
to the child after fork(2).
```

In addition, mmap() can cause problems with a strong deceleration
of the system during the fork() to run processes that perform IST/SST.
Moreover, we may face a sudden error due to lack of memory due to false
alarm, which may be raised by memory overcommitment heuristics in
the Linux kernel.

To avoid all these problems, it is necessary to mark all the large pools
and buffers as MADV_DONTFORK (+ corresponding equivalent from FreeBSD,
as supposed in https://github.com/percona/percona-xtradb-cluster/pull/108),
which is done in this patch.

The related PXC patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/367