### PR TITLE
- #PXC-393: Optimized and accurate way to get mmap file gcache size using mincore syscall

### DIFF
--- a/common/wsrep_api.h
+++ b/common/wsrep_api.h
@@ -999,6 +999,15 @@ struct wsrep {
     struct wsrep_stats_var* (*stats_get) (wsrep_t* wsrep);
 
   /*!
+   * @brief Returns an array of extended status variables.
+   *        Array is terminated by Null variable name.
+   *
+   * @param wsrep provider handle
+   * @return array of struct wsrep_status_var.
+   */
+    struct wsrep_stats_var* (*stats_ext_get) (wsrep_t* wsrep);
+
+  /*!
    * @brief Release resources that might be associated with the array.
    *
    * @param wsrep     provider handle.

--- a/galera/src/replicator.hpp
+++ b/galera/src/replicator.hpp
@@ -112,6 +112,7 @@ namespace galera
         virtual void process_sync(wsrep_seqno_t seqno_l) = 0;
 
         virtual const struct wsrep_stats_var* stats_get() = 0;
+        virtual const struct wsrep_stats_var* stats_ext_get() = 0;
         virtual void                          stats_reset() = 0;
         // static void stats_free(struct wsrep_stats_var*) must be declared in
         // the child class

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -197,7 +197,8 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     preordered_id_      (),
     incoming_list_      (""),
     incoming_mutex_     (),
-    wsrep_stats_        ()
+    wsrep_stats_        (),
+    wsrep_stats_ext_    ()
 {
     /*
       Register the application callback that should be called
@@ -278,6 +279,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     cert_.assign_initial_position(seqno, trx_proto_ver());
 
     build_stats_vars(wsrep_stats_);
+    build_stats_ext_vars(wsrep_stats_ext_);
 }
 
 galera::ReplicatorSMM::~ReplicatorSMM()

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -136,6 +136,7 @@ namespace galera
         void process_sync(wsrep_seqno_t seqno_l);
 
         const struct wsrep_stats_var* stats_get();
+        const struct wsrep_stats_var* stats_ext_get();
         void                          stats_reset();
         void                   stats_free(struct wsrep_stats_var*);
 
@@ -457,6 +458,7 @@ namespace galera
         };
 
         void build_stats_vars (std::vector<struct wsrep_stats_var>& stats);
+        void build_stats_ext_vars (std::vector<struct wsrep_stats_var>& stats);
 
         void establish_protocol_versions (int version);
 
@@ -616,6 +618,7 @@ namespace galera
         mutable gu::Mutex     incoming_mutex_;
 
         mutable std::vector<struct wsrep_stats_var> wsrep_stats_;
+        mutable std::vector<struct wsrep_stats_var> wsrep_stats_ext_;
     };
 
     std::ostream& operator<<(std::ostream& os, ReplicatorSMM::State state);

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -926,6 +926,17 @@ struct wsrep_stats_var* galera_stats_get (wsrep_t* gh)
 }
 
 
+struct wsrep_stats_var* galera_stats_ext_get (wsrep_t* gh)
+{
+    assert(gh != 0);
+    assert(gh->ctx != 0);
+
+    REPL_CLASS* repl(reinterpret_cast< REPL_CLASS * >(gh->ctx));
+
+    return const_cast<struct wsrep_stats_var*>(repl->stats_ext_get());
+}
+
+
 extern "C"
 void galera_stats_free (wsrep_t* gh, struct wsrep_stats_var* s)
 {
@@ -1095,6 +1106,7 @@ static wsrep_t galera_str = {
     &galera_sst_received,
     &galera_snapshot,
     &galera_stats_get,
+    &galera_stats_ext_get,
     &galera_stats_free,
     &galera_stats_reset,
     &galera_pause,

--- a/galerautils/src/gu_mmap.hpp
+++ b/galerautils/src/gu_mmap.hpp
@@ -40,4 +40,7 @@ private:
 
 } /* namespace gu */
 
+/** Returns actual memory usage by allocated page range: **/
+size_t gu_actual_memory_usage (const void * const ptr, const size_t length);
+
 #endif /* __GCACHE_MMAP__ */

--- a/gcache/src/GCache.cpp
+++ b/gcache/src/GCache.cpp
@@ -73,6 +73,14 @@ namespace gcache
                   << "\n" << "GCache frees   : " << frees;
     }
 
+    size_t GCache::actual_pool_size ()
+    {
+        gu::Lock lock(mtx);
+        return mem.actual_pool_size() +
+               rb.actual_pool_size(&mtx) +
+               ps.actual_pool_size(&mtx);
+    }
+
     size_t GCache::allocated_pool_size ()
     {
         gu::Lock lock(mtx);

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -100,6 +100,11 @@ namespace gcache
                                    ssize_t& size);
 
         /*!
+         * Returns actual gcache memory pool size (in bytes).
+         */
+        size_t actual_pool_size ();
+
+        /*!
          * Returns allocated gcache memory pool size (in bytes).
          */
         size_t allocated_pool_size ();

--- a/gcache/src/gcache_mem_store.cpp
+++ b/gcache/src/gcache_mem_store.cpp
@@ -75,6 +75,11 @@ MemStore::seqno_reset()
     }
 }
 
+size_t MemStore::actual_pool_size ()
+{
+  return size_;
+}
+
 size_t MemStore::allocated_pool_size ()
 {
   return size_;

--- a/gcache/src/gcache_mem_store.hpp
+++ b/gcache/src/gcache_mem_store.hpp
@@ -135,6 +135,7 @@ namespace gcache
         // for unit tests only
         size_t _allocd () const { return size_; }
 
+        size_t actual_pool_size ();
         size_t allocated_pool_size ();
 
     private:

--- a/gcache/src/gcache_page.cpp
+++ b/gcache/src/gcache_page.cpp
@@ -169,6 +169,17 @@ gcache::Page::realloc (void* ptr, size_type size)
     }
 }
 
+size_t gcache::Page::actual_pool_size (gu::Mutex * mtx)
+{
+    void*  ptr= reinterpret_cast<void *> (mmap_.ptr);
+    size_t used= mmap_.size - min_space_;
+    size_t size;
+    mtx->unlock();
+    size = gu_actual_memory_usage(ptr, used);
+    mtx->lock();
+    return size;
+}
+
 size_t gcache::Page::allocated_pool_size ()
 {
     return mmap_.size - min_space_;

--- a/gcache/src/gcache_page.hpp
+++ b/gcache/src/gcache_page.hpp
@@ -10,8 +10,9 @@
 #include "gcache_memops.hpp"
 #include "gcache_bh.hpp"
 
-#include "gu_fdesc.hpp"
-#include "gu_mmap.hpp"
+#include <gu_fdesc.hpp>
+#include <gu_mmap.hpp>
+#include <gu_lock.hpp>
 
 #include <string>
 
@@ -53,6 +54,7 @@ namespace gcache
 
         void* parent() const { return ps_; }
 
+        size_t actual_pool_size (gu::Mutex * mtx);
         size_t allocated_pool_size ();
 
     private:

--- a/gcache/src/gcache_page_store.hpp
+++ b/gcache/src/gcache_page_store.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <deque>
 
+#include <gu_lock.hpp>
+
 namespace gcache
 {
     class PageStore : public MemOps
@@ -54,6 +56,7 @@ namespace gcache
 
         void  set_keep_count (size_t count) { keep_page_ = count; cleanup();}
 
+        size_t actual_pool_size (gu::Mutex * mtx);
         size_t allocated_pool_size ();
 
         /* for unit tests */
@@ -63,6 +66,7 @@ namespace gcache
 
     private:
 
+        gu::Mutex         mtx_;
         std::string const base_name_; /* /.../.../gcache.page. */
         size_t            keep_size_; /* how much pages to keep after freeing*/
         size_t            page_size_; /* min size of the individual page */

--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -530,6 +530,17 @@ namespace gcache
         /* this is needed to avoid rescanning from start_ on recovery */
     }
 
+    size_t RingBuffer::actual_pool_size (gu::Mutex * mtx)
+    {
+       void*  ptr= reinterpret_cast<void *> (mmap_.ptr);
+       size_t used= max_used_;
+       size_t size;
+       mtx->unlock();
+       size = gu_actual_memory_usage(ptr, used);
+       mtx->lock();
+       return size;
+    }
+
     size_t RingBuffer::allocated_pool_size ()
     {
        return max_used_;

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -14,6 +14,7 @@
 #include <gu_fdesc.hpp>
 #include <gu_mmap.hpp>
 #include <gu_uuid.hpp>
+#include <gu_lock.hpp>
 
 #include <string>
 
@@ -111,6 +112,7 @@ namespace gcache
             assert_size_free();
         }
 
+        size_t actual_pool_size (gu::Mutex * mtx);
         size_t allocated_pool_size ();
 
     private:


### PR DESCRIPTION
This patch implements a new information schema table ("WSREP_STATS"),
which contains the "wsrep_gcache_actual_pool_size" variable that reflects
the exact amount of memory, which is used by the "gcache" memory pool.

Using a separate information schema table for this variable avoids
deceleration of regular queries, such as SHOW STATUS.

To determine the actual amount of memory occupied by the gcache,
the mincore() syscall is used.

At the same time, I limited the size of additional vector, which used
by mincore() syscall, by dividing of large memory ranges into relatively
small 512MB chunks, which are passed to mincore() syscall. This introduces
slight performance loss due to additional syscalls, however, these costs
is less than 1%, while only the 128 kilobytes of additional memory is
allocated for mincore()-related vector.

I made sure that the state of gcache pages measured only up to the
currently achieved "watermark", but not around the entire allocated
pool - to accelerate scenarios such as
https://bugs.launchpad.net/percona-xtradb-cluster/+bug/1462674

In addition, measurement of the actual amount of memory occupied
by the gcache avoids long-term locking of the other gcache operations,
except when mutex is aquired by the allocation or deallocation of
overflow pages (in the "Pages" storage). In this case mid-term
locking is possible – until the code that uses memcore() syscall
will stop working. However, while we do not create/free the overflow
pages, a global lock does not happen.

The related PXC patch is located here: https://github.com/percona/percona-xtradb-cluster/pull/368