### PR TITLE
Fix PXC-760 : gcache.page files not being deleted

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -807,7 +807,7 @@ galera::Certification::do_test_preordered(TrxHandle* trx)
 }
 
 
-galera::Certification::Certification(gu::Config& conf, ServiceThd& thd)
+galera::Certification::Certification(gu::Config& conf, ServiceThd& thd, gcache::GCache& gcache)
     :
     version_               (-1),
     trx_map_               (),
@@ -815,6 +815,7 @@ galera::Certification::Certification(gu::Config& conf, ServiceThd& thd)
     cert_index_ng_         (),
     deps_set_              (),
     service_thd_           (thd),
+    gcache_                (gcache),
     mutex_                 (),
     trx_size_warn_count_   (0),
     initial_position_      (-1),
@@ -1065,7 +1066,7 @@ wsrep_seqno_t galera::Certification::set_trx_committed(TrxHandle* trx)
             deps_set_.erase(i);
         }
 
-        if (gu_unlikely(index_purge_required()))
+        if (gu_unlikely(gcache_.cleanup_required() || index_purge_required()))
         {
             ret = get_safe_to_discard_seqno_();
         }

--- a/galera/src/certification.hpp
+++ b/galera/src/certification.hpp
@@ -48,7 +48,7 @@ namespace galera
             TEST_FAILED
         } TestResult;
 
-        Certification(gu::Config& conf, ServiceThd& thd);
+        Certification(gu::Config& conf, ServiceThd& thd, gcache::GCache& gcache);
         ~Certification();
 
         void assign_initial_position(wsrep_seqno_t seqno, int versiono);
@@ -189,6 +189,7 @@ namespace galera
         CertIndexNG   cert_index_ng_;
         DepsSet       deps_set_;
         ServiceThd&   service_thd_;
+        gcache::GCache& gcache_;
         gu::Mutex     mutex_;
         size_t        trx_size_warn_count_;
         wsrep_seqno_t initial_position_;

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -177,7 +177,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     ist_prepared_       (false),
     ist_senders_        (gcs_, gcache_),
     wsdb_               (),
-    cert_               (config_, service_thd_),
+    cert_               (config_, service_thd_, gcache_),
     local_monitor_      (),
     apply_monitor_      (),
     commit_monitor_     (),

--- a/galera/tests/write_set_check.cpp
+++ b/galera/tests/write_set_check.cpp
@@ -51,6 +51,7 @@ namespace
 
         gu::Config&         conf() { return conf_; }
         galera::ServiceThd& thd()  { return thd_;  }
+        gcache::GCache&     gcache() { return gcache_; }
 
     private:
 
@@ -408,7 +409,7 @@ START_TEST(test_cert_hierarchical_v1)
     size_t nws(sizeof(wsi)/sizeof(wsi[0]));
 
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
     int const version(1);
     cert.assign_initial_position(0, version);
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
@@ -530,7 +531,7 @@ START_TEST(test_cert_hierarchical_v2)
     size_t nws(sizeof(wsi)/sizeof(wsi[0]));
 
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
 
     cert.assign_initial_position(0, version);
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
@@ -580,7 +581,7 @@ START_TEST(test_trac_726)
 
     const int version(2);
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
     wsrep_uuid_t uuid1 = {{1, }};
     wsrep_uuid_t uuid2 = {{2, }};

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -104,6 +104,17 @@ namespace gcache
          */
         size_t allocated_pool_size ();
 
+
+        /*!
+         * Implements the cleanup policy test.
+         */
+        bool cleanup_required()
+        {
+            return (params.keep_pages_size() && ps.total_size() > params.keep_pages_size()) ||
+                   (params.keep_pages_count() && ps.total_pages() > params.keep_pages_count());
+        }
+
+
         class Buffer
         {
         public:


### PR DESCRIPTION
Fix PXC-686 : Review semantics of gcache keep_pages_size and keep_pages_count

Issue
(760) When the limits on the gcache were exceeded (using gcache.keep_pages_size or
gcache.keep_pages_count), the files were not being deleted on a timely basis.
The decision on discard the seqnos was decided with static constants within
index_purge_required()

(686) The semantics of the gcache.keep_pages_size and gcache.keep_pages_count is
confusing because we are doing an AND condition (most people expect an OR).

Solution
Adding an extra call (GCache::cleanup_required) that checks the page store
within the gcache to see if the limits have been reached.  This is called
along index_purge_required().

Also, change the limits check to an OR.