### PR TITLE
Fix PXC-760 : gcache.page files not being deleted

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -807,7 +807,7 @@ galera::Certification::do_test_preordered(TrxHandle* trx)
 }
 
 
-galera::Certification::Certification(gu::Config& conf, ServiceThd& thd)
+galera::Certification::Certification(gu::Config& conf, ServiceThd& thd, gcache::GCache& gcache)
     :
     version_               (-1),
     trx_map_               (),
@@ -815,6 +815,7 @@ galera::Certification::Certification(gu::Config& conf, ServiceThd& thd)
     cert_index_ng_         (),
     deps_set_              (),
     service_thd_           (thd),
+    gcache_                (gcache),
 #ifdef HAVE_PSI_INTERFACE
     mutex_                 (WSREP_PFS_INSTR_TAG_CERT_MUTEX),
 #else
@@ -1073,7 +1074,7 @@ wsrep_seqno_t galera::Certification::set_trx_committed(TrxHandle* trx)
             deps_set_.erase(i);
         }
 
-        if (gu_unlikely(index_purge_required()))
+        if (gu_unlikely(gcache_.cleanup_required() || index_purge_required()))
         {
             ret = get_safe_to_discard_seqno_();
         }

--- a/galera/src/certification.hpp
+++ b/galera/src/certification.hpp
@@ -48,7 +48,7 @@ namespace galera
             TEST_FAILED
         } TestResult;
 
-        Certification(gu::Config& conf, ServiceThd& thd);
+        Certification(gu::Config& conf, ServiceThd& thd, gcache::GCache& gcache);
         ~Certification();
 
         void assign_initial_position(wsrep_seqno_t seqno, int versiono);
@@ -189,6 +189,7 @@ namespace galera
         CertIndexNG   cert_index_ng_;
         DepsSet       deps_set_;
         ServiceThd&   service_thd_;
+        gcache::GCache& gcache_;
 #ifdef HAVE_PSI_INTERFACE
         gu::MutexWithPFS
                       mutex_;

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -183,7 +183,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     ist_prepared_       (false),
     ist_senders_        (gcs_, gcache_),
     wsdb_               (),
-    cert_               (config_, service_thd_),
+    cert_               (config_, service_thd_, gcache_),
 #ifdef HAVE_PSI_INTERFACE
     local_monitor_      (WSREP_PFS_INSTR_TAG_LOCAL_MONITOR_MUTEX,
                          WSREP_PFS_INSTR_TAG_LOCAL_MONITOR_CONDVAR),

--- a/galera/tests/write_set_check.cpp
+++ b/galera/tests/write_set_check.cpp
@@ -51,6 +51,7 @@ namespace
 
         gu::Config&         conf() { return conf_; }
         galera::ServiceThd& thd()  { return thd_;  }
+        gcache::GCache&     gcache() { return gcache_; }
 
     private:
 
@@ -408,7 +409,7 @@ START_TEST(test_cert_hierarchical_v1)
     size_t nws(sizeof(wsi)/sizeof(wsi[0]));
 
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
     int const version(1);
     cert.assign_initial_position(0, version);
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
@@ -530,7 +531,7 @@ START_TEST(test_cert_hierarchical_v2)
     size_t nws(sizeof(wsi)/sizeof(wsi[0]));
 
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
 
     cert.assign_initial_position(0, version);
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
@@ -580,7 +581,7 @@ START_TEST(test_trac_726)
 
     const int version(2);
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
     wsrep_uuid_t uuid1 = {{1, }};
     wsrep_uuid_t uuid2 = {{2, }};

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -104,6 +104,17 @@ namespace gcache
          */
         size_t allocated_pool_size ();
 
+
+        /*!
+         * Implements the cleanup policy test.
+         */
+        bool cleanup_required()
+        {
+            return (params.keep_pages_size() && ps.total_size() > params.keep_pages_size()) ||
+                   (params.keep_pages_count() && ps.total_pages() > params.keep_pages_count());
+        }
+
+
         class Buffer
         {
         public:

--- a/gcache/src/gcache_page_store.cpp
+++ b/gcache/src/gcache_page_store.cpp
@@ -90,9 +90,16 @@ remove_file (void* __restrict__ arg)
     pthread_exit(NULL);
 }
 
+/*
+ * Returns false if there are no more pages to be deleted (either
+ * the queue is empty or if the first page is in use).
+ * Otherwise, returns true.
+*/
 bool
 gcache::PageStore::delete_page ()
 {
+    if (pages_.empty()) return false;
+
     Page* const page = pages_.front();
 
     if (page->used() > 0) return false;
@@ -134,41 +141,18 @@ gcache::PageStore::cleanup ()
     size_t counter = 0;
 #endif
 /*
- * 1. We must release the page if we have exceeded the limit on the
+ * 1. We must release the page if the size (keep_size_ = gcache.keep_pages_size)
+ *    and count (keep_page_ = gcache.keep_pages_count) are NOT set (they are both 0).
+ * 2. We must release the page if we have exceeded the limit on the
  *    overall size of the page pool (which is set by the user explicitly,
- *    keep_size_ = gcache.keep_pages_size) and if the quantity of pages
+ *    keep_size_ = gcache.keep_pages_size) OR if the quantity of pages
  *    more that we should to keep in memory even if they are free (parameter
  *    keep_page_ = gcache.keep_pages_count).
- * 2. We shall release the pages, if the number of pages exceeds keep_page_
- *    (gcache.keep_pages_count) and total size of the pool is not explicitly
- *    specified (keep_size_ = gcache.keep_pages_size = 0).
- * 3. We should not release the first page when the total limit is not
- *    specified explicitly (keep_size_ = gcache.keep_pages_size = 0) and
- *    the number of pages, which must be retained in memory, is greater
- *    than one: keep_page_ (gcache.keep_pages_count) >= 1.
- * 4. If the user changes the page size, then we should get rid of the pages
- *    with old size at the earliest opportunity. The fact that the user can
- *    specify the desired total memory not only through gcache.keep_pages_size
- *    (keep_size_) parameter, but alternatively by specifying the total number
- *    of retained pages (gcache.keep_pages_count = keep_page_) and the size
- *    of one page (gcache.page_size = page_size_).
- * 5. We must get rid of the non-standard page size, even if not exceeded
- *    the total number of pages. Otherwise, the user will not be able to
- *    reduce the effective size of the page pool by changing the page size
- *    (gcache.page_size = page_size_).
- * 6. We note that gcache.keep_pages_size (keep_size_) parameter is zero,
- *    if we do not set it explicitly. Therefore, the first condition
- *    "total_size_ > keep_size_" is not interfere with the third condition
- *    "pages_.front()->size() != page_size_" in scenarios where the user
- *    has decided to limit the volume of the pool by specifying the size
- *    of one page (gcache.page_size = page_size_) and the total number
- *    of retained pages (gcache.keep_pages_count  = keep_page_), rather
- *    than through a clear indication of the total amount of memory
- *    (keep_size_ = gcache.keep_pages_size).
+ * 3. 
  */
-    while (total_size_   > keep_size_ &&
-          (pages_.size() > keep_page_ ||
-           pages_.front()->size() != page_size_) &&
+    while (((!keep_size_ && !keep_page_) ||
+            (keep_size_ && total_size_ > keep_size_) ||
+            (keep_page_ && pages_.size() > keep_page_)) &&
            delete_page())
     {
 #ifndef NDEBUG


### PR DESCRIPTION
Fix PXC-686 : Review semantics of gcache keep_pages_size and keep_pages_count

Issue
(760) When the limits on the gcache were exceeded (using gcache.keep_pages_size or
gcache.keep_pages_count), the files were not being deleted on a timely basis.
The decision on discard the seqnos was decided with static constants within
index_purge_required()

(686) The semantics of the gcache.keep_pages_size and gcache.keep_pages_count is
confusing because we are doing an AND condition (most people expect an OR).

Solution
Adding an extra call (GCache::cleanup_required) that checks the page store
within the gcache to see if the limits have been reached.  This is called
along index_purge_required().

Also, change the limits check to an OR.