### PR TITLE
Fix PXC-759 : Explictly show variable to indicate if node is in flow …

### DIFF
--- a/galera/src/replicator_smm_stats.cpp
+++ b/galera/src/replicator_smm_stats.cpp
@@ -102,6 +102,7 @@ typedef enum status_vars
     STATS_FC_SENT,
     STATS_FC_RECEIVED,
     STATS_FC_INTERVAL,
+    STATS_FC_STATUS,
     STATS_CERT_DEPS_DISTANCE,
     STATS_APPLY_OOOE,
     STATS_APPLY_OOOL,
@@ -150,6 +151,7 @@ static const struct wsrep_stats_var wsrep_stats[STATS_MAX + 1] =
     { "flow_control_sent",        WSREP_VAR_INT64,  { 0 }  },
     { "flow_control_recv",        WSREP_VAR_INT64,  { 0 }  },
     { "flow_control_interval",    WSREP_VAR_STRING, { 0 }  },
+    { "flow_control_status",      WSREP_VAR_STRING, { 0 }  },
     { "cert_deps_distance",       WSREP_VAR_DOUBLE, { 0 }  },
     { "apply_oooe",               WSREP_VAR_DOUBLE, { 0 }  },
     { "apply_oool",               WSREP_VAR_DOUBLE, { 0 }  },
@@ -227,8 +229,7 @@ galera::ReplicatorSMM::stats_get()
     sv[STATS_FC_SENT             ].value._int64  = stats.fc_sent;
     sv[STATS_FC_RECEIVED         ].value._int64  = stats.fc_received;
     sv[STATS_FC_INTERVAL         ].value._string = interval;
-
-
+    sv[STATS_FC_STATUS           ].value._string = (stats.fc_status ? "ON" : "OFF");
 
     double avg_cert_interval(0);
     double avg_deps_dist(0);

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -722,6 +722,9 @@ _release_sst_flow_control (gcs_conn_t* conn)
         if (conn->stop_sent > 0) {
             ret = gcs_send_fc_event (conn, GCS_FC_CONT);
             conn->stop_sent -= (ret >= 0);
+
+            if (ret >= 0)
+                gu_info("SST leaving flow control");
         }
     }
     while (ret < 0 && -EAGAIN == ret); // we need to send CONT here at all costs
@@ -1112,6 +1115,8 @@ _check_recv_queue_growth (gcs_conn_t* conn, ssize_t size)
             if ((ret = gcs_send_fc_event (conn, GCS_FC_STOP)) >= 0) {
                 conn->stop_sent++;
                 ret = 0;
+
+                gu_info("SST entering flow control");
             }
             else {
                 ret = gcs_check_error (ret, "Failed to send SST FC_STOP.");
@@ -2034,6 +2039,8 @@ gcs_get_stats (gcs_conn_t* conn, struct gcs_stats* stats)
 
     stats->fc_lower_limit = conn->lower_limit;
     stats->fc_upper_limit = conn->upper_limit;
+
+    stats->fc_status = conn->stop_sent > 0 ? 1 : 0;
 }
 
 void

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -442,6 +442,7 @@ struct gcs_stats
     int       send_q_len_min; //! minimum send queue length
     long      fc_lower_limit; //! Flow-control interval lower limit
     long      fc_upper_limit; //! Flow-control interval upper limit
+    int       fc_status;      //! Flow-control status (ON=1/OFF=0)
     gcs_backend_stats_t backend_stats; //! backend stats.
 };
 


### PR DESCRIPTION
…control (paused)

Issue
When a PXC node enters flow control, there is no way of knowing that it
has done so.  This would be useful for debugging, especially if a
node is causing other nodes to block.

Solution
Add a status variable, 'wsrep_flow_control_status' that has the
values of 'ON' or 'OFF'.  'ON' indicates that the node is in
flow control.