### PR TITLE
- PXC#784: pc.recovery fails with unclear error when gvwstate.dat is …

### DIFF
--- a/gcomm/src/gcomm/view.hpp
+++ b/gcomm/src/gcomm/view.hpp
@@ -18,6 +18,9 @@
 
 namespace gcomm
 {
+    /*! Some utility exceptions to indicate special conditions. */
+    class ViewParseError {};
+
     typedef enum
     {
         V_NONE     = -1,

--- a/gcomm/src/view.cpp
+++ b/gcomm/src/view.cpp
@@ -221,6 +221,8 @@ std::istream& gcomm::View::read_stream(std::istream& is)
             uuid.read_stream(istr);
             node.read_stream(istr);
             add_member(uuid, node.segment());
+        } else {
+            throw gcomm::ViewParseError();
         }
     }
     return is;
@@ -248,6 +250,8 @@ std::istream& gcomm::ViewState::read_stream(std::istream& is)
         } else if (param == "#vwbeg") {
             // read from next line.
             view_.read_stream(is);
+        } else {
+            throw gcomm::ViewParseError();
         }
     }
     return is;
@@ -390,6 +394,10 @@ bool gcomm::ViewState::read_file()
         read_stream(ifs);
         ifs.close();
         return true;
+    } catch (gcomm::ViewParseError& e) {
+        log_warn << "error parsing file(" << file_name_ << ") "
+                 << "can't restore pc from said file";
+        return false;
     } catch (const std::exception& e) {
         log_warn << "read file(" << file_name_ << ") failed("
                  << e.what() << ")";


### PR DESCRIPTION
…empty

  Issue
  -----

  - if the said gvwstate.dat file has invalid or empty content, parser
    still continue to parse the file w/o reporting error.
  - this wrongly create an impression that the pc has been restored from
    the file when it isn't
  - node bootup will eventually fail with wrong/invalid uuid error
    (as uuid is not read from the said file)

  All this confuses user and user need to remove the file manually
  in-order to continue boot the node.

  Fix:
  ----

  - detect and report the parsing error so that restore of primary component
    from file can be skipped and node can boot directly.

  (Ideally gvwstate.dat should never have invalid content).