### PR TITLE
Fix PXC-766: Show progress during an IST

### DIFF
--- a/galera/src/ist.cpp
+++ b/galera/src/ist.cpp
@@ -101,6 +101,7 @@ galera::ist::Receiver::Receiver(gu::Config&           conf,
 #endif /* HAVE_PSI_INTERFACE */
     consumers_    (),
     current_seqno_(-1),
+    first_seqno_  (-1),
     last_seqno_   (-1),
     conf_         (conf),
     trx_pool_     (sp),
@@ -353,6 +354,7 @@ galera::ist::Receiver::prepare(wsrep_seqno_t first_seqno,
     }
 
     current_seqno_ = first_seqno;
+    first_seqno_   = first_seqno;
     last_seqno_    = last_seqno;
     int err;
     if ((err = gu_thread_create(&thread_, 0, &run_receiver_thread, this)) != 0)

--- a/galera/src/ist.hpp
+++ b/galera/src/ist.hpp
@@ -47,6 +47,11 @@ namespace galera
             wsrep_seqno_t finished();
             void          run();
 
+            wsrep_seqno_t current_seqno()   { return current_seqno_; }
+            wsrep_seqno_t first_seqno()     { return first_seqno_; }
+            wsrep_seqno_t last_seqno()      { return last_seqno_; }
+            bool          running()         { return running_; }
+
         private:
 
             void interrupt();
@@ -103,6 +108,7 @@ namespace galera
 
             std::stack<Consumer*> consumers_;
             wsrep_seqno_t         current_seqno_;
+            wsrep_seqno_t         first_seqno_;
             wsrep_seqno_t         last_seqno_;
             gu::Config&           conf_;
             TrxHandle::SlavePool& trx_pool_;

--- a/galera/src/replicator_smm_stats.cpp
+++ b/galera/src/replicator_smm_stats.cpp
@@ -117,6 +117,7 @@ typedef enum status_vars
     STATS_GCACHE_POOL_SIZE,
     STATS_CAUSAL_READS,
     STATS_CERT_INTERVAL,
+    STATS_IST_RECEIVE_STATUS,
     STATS_INCOMING_LIST,
     STATS_MAX
 } StatusVars;
@@ -166,6 +167,7 @@ static const struct wsrep_stats_var wsrep_stats[STATS_MAX + 1] =
     { "gcache_pool_size",         WSREP_VAR_INT64,  { 0 }  },
     { "causal_reads",             WSREP_VAR_INT64,  { 0 }  },
     { "cert_interval",            WSREP_VAR_DOUBLE, { 0 }  },
+    { "ist_receive_status",       WSREP_VAR_STRING, { 0 }  },
     { "incoming_addresses",       WSREP_VAR_STRING, { 0 }  },
     { 0,                          WSREP_VAR_STRING, { 0 }  }
 };
@@ -191,6 +193,8 @@ galera::ReplicatorSMM::stats_get()
     if (S_DESTROYED == state_()) return 0;
 
     std::vector<struct wsrep_stats_var> sv(wsrep_stats_);
+    char    interval_text[64];
+    char    ist_status_text[128];
 
     sv[STATS_PROTOCOL_VERSION   ].value._int64  = protocol_version_;
     sv[STATS_LAST_APPLIED       ].value._int64  = apply_monitor_.last_left();
@@ -210,9 +214,6 @@ galera::ReplicatorSMM::stats_get()
     gcs_.get_stats (&stats);
 
     int64_t seqno_min = gcache_.seqno_min();
-    char    interval[64];
-    snprintf(interval, sizeof(interval), "[ %ld, %ld ]",
-             stats.fc_lower_limit, stats.fc_upper_limit);
 
     sv[STATS_LOCAL_SEND_QUEUE    ].value._int64  = stats.send_q_len;
     sv[STATS_LOCAL_SEND_QUEUE_MAX].value._int64  = stats.send_q_len_max;
@@ -228,7 +229,10 @@ galera::ReplicatorSMM::stats_get()
     sv[STATS_FC_PAUSED_AVG       ].value._double = stats.fc_paused_avg;
     sv[STATS_FC_SENT             ].value._int64  = stats.fc_sent;
     sv[STATS_FC_RECEIVED         ].value._int64  = stats.fc_received;
-    sv[STATS_FC_INTERVAL         ].value._string = interval;
+
+    snprintf(interval_text, sizeof(interval_text), "[ %ld, %ld ]",
+             stats.fc_lower_limit, stats.fc_upper_limit);
+    sv[STATS_FC_INTERVAL         ].value._string = interval_text;
     sv[STATS_FC_STATUS           ].value._string = (stats.fc_status ? "ON" : "OFF");
 
     double avg_cert_interval(0);
@@ -265,6 +269,29 @@ galera::ReplicatorSMM::stats_get()
     sv[STATS_LOCAL_STATE_COMMENT ].value._string = state2stats_str(state_(),
                                                                    sst_state_);
     sv[STATS_CAUSAL_READS].value._int64    = causal_reads_();
+
+    if (ist_receiver_.running())
+    {
+        // calculate %-age complete
+        int percent_complete = 100;
+        wsrep_seqno_t   first = ist_receiver_.first_seqno();
+        wsrep_seqno_t   last = ist_receiver_.last_seqno();
+        wsrep_seqno_t   current = ist_receiver_.current_seqno() - 1;
+
+        if (last > first)
+            percent_complete = 100.0 * static_cast<float>(current - first) / static_cast<float>(last - first);
+        percent_complete = std::max(percent_complete, 0);
+        percent_complete = std::min(percent_complete, 100);
+
+        snprintf(ist_status_text, sizeof(ist_status_text),
+                 "%d%% complete, received seqno %lld of %lld-%lld",
+                 percent_complete, static_cast<long long>(current),
+                                   static_cast<long long>(first),
+                                   static_cast<long long>(last));
+        sv[STATS_IST_RECEIVE_STATUS].value._string = ist_status_text;
+    }
+    else
+        sv[STATS_IST_RECEIVE_STATUS].value._string = "";
 
     // Get gcs backend status
     gu::Status status;


### PR DESCRIPTION
Issue
During a slow IST, there's no way of knowing if the system is making progress
(or how far along it is).

Solution
Add a status variable that can be queried for the IST status.