### PR TITLE
- PXC#692: Improving error/logging messages for PXC

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -849,17 +849,17 @@ galera::Certification::Certification(gu::Config& conf, ServiceThd& thd, gcache::
 
 galera::Certification::~Certification()
 {
-    log_info << "cert index usage at exit "   << cert_index_.size();
-    log_info << "cert trx map usage at exit " << trx_map_.size();
-    log_info << "deps set usage at exit "     << deps_set_.size();
+    log_debug << "cert index usage at exit "   << cert_index_.size();
+    log_debug << "cert trx map usage at exit " << trx_map_.size();
+    log_debug << "deps set usage at exit "     << deps_set_.size();
 
     double avg_cert_interval(0);
     double avg_deps_dist(0);
     size_t index_size(0);
     stats_get(avg_cert_interval, avg_deps_dist, index_size);
-    log_info << "avg deps dist "              << avg_deps_dist;
-    log_info << "avg cert interval "          << avg_cert_interval;
-    log_info << "cert index size "            << index_size;
+    log_debug << "avg deps dist "              << avg_deps_dist;
+    log_debug << "avg cert interval "          << avg_cert_interval;
+    log_debug << "cert index size "            << index_size;
 
     gu::Lock lock(mutex_);
 

--- a/galera/src/monitor.hpp
+++ b/galera/src/monitor.hpp
@@ -72,13 +72,13 @@ namespace galera
             delete[] process_;
             if (entered_ > 0)
             {
-                log_info << "mon: entered " << entered_
+                log_debug << "mon: entered " << entered_
                          << " oooe fraction " << double(oooe_)/entered_
                          << " oool fraction " << double(oool_)/entered_;
             }
             else
             {
-                log_info << "apply mon: entered 0";
+                log_debug << "apply mon: entered 0";
             }
         }
 

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -302,7 +302,7 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
 
 galera::ReplicatorSMM::~ReplicatorSMM()
 {
-    log_info << "dtor state: " << state_();
+    log_debug << "dtor state: " << state_();
     switch (state_())
     {
     case S_CONNECTED:

--- a/galera/src/saved_state.cpp
+++ b/galera/src/saved_state.cpp
@@ -46,6 +46,7 @@ SavedState::SavedState  (const std::string& file) :
     if (ifs.fail())
     {
         log_warn << "Could not open state file for reading: '" << file << '\'';
+        log_warn << "No persistent state found. Bootstraping with default state";
     }
 
     fs_ = fopen(file.c_str(), "a");

--- a/galera/src/wsdb.cpp
+++ b/galera/src/wsdb.cpp
@@ -51,9 +51,9 @@ galera::Wsdb::Wsdb()
 
 galera::Wsdb::~Wsdb()
 {
-    log_info << "wsdb trx map usage " << trx_map_.size()
+    log_debug << "wsdb trx map usage " << trx_map_.size()
              << " conn query map usage " << conn_map_.size();
-    log_info << trx_pool_;
+    log_debug << trx_pool_;
 
     // With debug builds just print trx and query maps to stderr
     // and don't clean up to let valgrind etc to detect leaks.

--- a/galerautils/src/gu_mmap.cpp
+++ b/galerautils/src/gu_mmap.cpp
@@ -106,7 +106,7 @@ namespace gu
     void
     MMap::sync () const
     {
-        log_info << "Flushing memory map to disk...";
+        log_debug << "Flushing memory map to disk...";
         sync(ptr, size);
     }
 

--- a/gcomm/src/pc.cpp
+++ b/gcomm/src/pc.cpp
@@ -27,7 +27,7 @@ void gcomm::PC::handle_up(const void* cid, const Datagram& rb,
         ViewState vst(const_cast<UUID&>(uuid()),
                       const_cast<View&>(um.view()),
                       conf_);
-        log_info << "save pc into disk";
+        log_info << "Save the discovered primary-component to disk";
         vst.write_file();
     }
     send_up(rb, um);
@@ -250,13 +250,15 @@ gcomm::PC::PC(Protonet& net, const gu::URI& uri) :
     ViewState vst(rst_uuid_, rst_view_, conf_);
     if (pc_recovery_) {
         if (vst.read_file()) {
-            log_info << "restore pc from disk successfully";
+            log_info << "Restoring primary-component from disk successful";
             restored = true;
         } else {
-            log_info << "restore pc from disk failed";
+            log_info << "Restoring primary-component from disk failed."
+                     << " Either node is booting for first time or re-booting"
+                     << " after a graceful shutdown";
         }
     } else {
-        log_info << "skip pc recovery and remove state file";
+        log_info << "Skip primary-component recovery and remove state file";
         ViewState::remove_file(conf_);
     }
 

--- a/gcomm/src/pc_proto.cpp
+++ b/gcomm/src/pc_proto.cpp
@@ -793,7 +793,7 @@ bool gcomm::pc::Proto::is_prim() const
 
         if (state.prim() == true)
         {
-            log_info << "Node " << SMMap::key(i) << " state prim";
+            log_info << "Node " << SMMap::key(i) << " state primary";
             prim      = true;
             last_prim = state.last_prim();
             to_seq    = state.to_seq();

--- a/gcomm/src/protonet.cpp
+++ b/gcomm/src/protonet.cpp
@@ -68,7 +68,7 @@ gcomm::Protonet* gcomm::Protonet::create(gu::Config& conf)
         gu_throw_error(EINVAL) << "invalid protonet version: " << version;
     }
 
-    log_info << "protonet " << backend << " version " << version;
+    log_debug << "protonet " << backend << " version " << version;
 
     if (backend == "asio")
         return new AsioProtonet(conf, version);

--- a/gcomm/src/view.cpp
+++ b/gcomm/src/view.cpp
@@ -160,23 +160,24 @@ bool gcomm::operator==(const gcomm::View& a, const gcomm::View& b)
 
 std::ostream& gcomm::operator<<(std::ostream& os, const gcomm::View& view)
 {
-    os << "view(";
+    os << "Current view of cluster as seen by this node\n";
+    os << "view (";
     if (view.is_empty() == true)
     {
         os << "(empty)";
     }
     else
     {
-        os << view.id();
-        os << " memb {\n";
+        os << view.id() << "\n";
+        os << "memb {\n";
         os << view.members();
-        os << "} joined {\n";
+        os << "\t}\njoined {\n";
         os << view.joined();
-        os << "} left {\n";
+        os << "\t}\nleft {\n";
         os << view.left();
-        os << "} partitioned {\n";
+        os << "\t}\npartitioned {\n";
         os << view.partitioned();
-        os << "}";
+        os << "\t}\n";
     }
     os << ")";
     return os;
@@ -381,8 +382,10 @@ void gcomm::ViewState::write_file() const
 bool gcomm::ViewState::read_file()
 {
     if (access(file_name_.c_str(), R_OK) != 0) {
-        log_warn << "access file(" << file_name_ << ") failed("
-                 << strerror(errno) << ")";
+        log_warn << "Fail to access the file (" << file_name_ << ") error ("
+                 << strerror(errno) << "). It is possible if node is booting"
+                 << " for first time or re-booting after a graceful shutdown";
+
         return false;
     }
     try {

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1421,7 +1421,7 @@ long gcs_open (gcs_conn_t* conn, const char* channel, const char* url,
                 gcs_fifo_lite_open(conn->repl_q);
                 gu_fifo_open(conn->recv_q);
                 gcs_shift_state (conn, GCS_CONN_OPEN);
-                gu_info ("Opened channel '%s'", channel);
+                gu_debug ("Opened channel '%s'", channel);
                 conn->inner_close_count = 0;
                 conn->outer_close_count = 0;
                 goto out;

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1249,7 +1249,7 @@ gcs_core_set_pkt_size (gcs_core_t* core, int const pkt_size)
      * size at this level */
     msg_size = std::min(std::max(min_msg_size, pkt_size), msg_size);
 
-    gu_info ("Changing maximum packet size to %d, resulting msg size: %d",
+    gu_debug ("Changing maximum packet size to %d, resulting msg size: %d",
              pkt_size, msg_size);
 
     int ret(msg_size - hdr_size); // message payload

--- a/gcs/src/gcs_gcomm.cpp
+++ b/gcs/src/gcs_gcomm.cpp
@@ -212,7 +212,7 @@ public:
         current_view_(),
         prof_("gcs_gcomm")
     {
-        log_info << "backend: " << net_->type();
+        log_debug << "backend: " << net_->type();
     }
 
     ~GCommConn()

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -353,7 +353,7 @@ group_post_state_exchange (gcs_group_t* group)
              "\n\tversion    = %u,"
              "\n\tcomponent  = %s,"
              "\n\tconf_id    = %lld,"
-             "\n\tmembers    = %d/%d (joined/total),"
+             "\n\tmembers    = %d/%d (primary/total),"
              "\n\tact_id     = %lld,"
              "\n\tlast_appl. = %lld,"
              "\n\tprotocols  = %d/%d/%d (gcs/repl/appl),"


### PR DESCRIPTION
  Existing PXC error/logging messages are cryptic to understand
  for non-technical end-user. Especially SST/IST messages.
  This fix is an attempt to fix them and make them user-friendly.