### PR TITLE
Fix PXC-758: Debug status output is misleading

### DIFF
--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -638,6 +638,10 @@ namespace galera
 #endif /* HAVE_PSI_INTERFACE */
 
         mutable std::vector<struct wsrep_stats_var> wsrep_stats_;
+
+        // Storage space for dynamic status strings
+        char                  interval_string_[64];
+        char                  ist_status_string_[128];
     };
 
     std::ostream& operator<<(std::ostream& os, ReplicatorSMM::State state);


### PR DESCRIPTION
    PXC-794: PXC SST: usability, prepend ',' to sockopt if needed
    PXC-795: PXC SST: set "--parallel=4" as default option to wsrep_sst_xtrabackup-v2

Issue:
PXC-758: status output does not check the result code before reporting result.
PXC-794: make the "sockopt" less error-prone
PXC-795: perf, increase use of threads when backing up on the donor

Solution:
PXC-758: check the result code and output the according output
PXC-794: prepend a comma (",") to the sockopt before using
PXC-795: add the "--parallel=4" to socat as a default