### PR TITLE
- PXC#823: Donor node enters permanent DESYNCED state after short net…

### DIFF
--- a/galera/src/galera_gcs.hpp
+++ b/galera/src/galera_gcs.hpp
@@ -233,6 +233,11 @@ namespace galera
 
         size_t  max_action_size() const { return GCS_MAX_ACT_SIZE; }
 
+        void join_notification()
+        {
+            gcs_join_notification(conn_);
+        }
+
     private:
 
         Gcs(const Gcs&);

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1232,6 +1232,13 @@ galera::ReplicatorSMM::sst_sent(const wsrep_gtid_t& state_id, int const rcode)
     if (state_() != S_DONOR)
     {
         log_error << "sst sent called when not SST donor, state " << state_();
+        /* If sst-sent fails node should restore itself back to joined state.
+        sst-sent can fail commonly due to n/w error where-in DONOR may loose
+        connectivity to JOINER (or existing cluster) but on re-join it should
+        restore the original state (DONOR->JOINER->JOINED->SYNCED) without
+        waiting for JOINER. sst-failure on JOINER will gracefully shutdown the
+        joiner. */
+        gcs_.join_notification();
         return WSREP_CONN_FAIL;
     }
 

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -151,6 +151,10 @@ struct gcs_conn
     /* #603, #606 join control */
     bool        volatile need_to_join;
     gcs_seqno_t volatile join_seqno;
+    void        join_notification()
+    {
+        need_to_join = true;
+    }
 
     /* sync control */
     bool         sync_sent_;
@@ -2274,4 +2278,10 @@ const char* gcs_param_get (gcs_conn_t* conn, const char* key)
     gu_warn ("Not implemented: %s", __FUNCTION__);
 
     return NULL;
+}
+
+
+void gcs_join_notification(gcs_conn_t* conn)
+{
+     conn->need_to_join = true;
 }

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -450,6 +450,8 @@ extern void gcs_flush_stats(gcs_conn_t *conn);
 
 void gcs_get_status(gcs_conn_t* conn, gu::Status& status);
 
+extern void gcs_join_notification(gcs_conn_t *conn);
+
 /*! A node with this name will be treated as a stateless arbitrator */
 #define GCS_ARBITRATOR_NAME "garb"
 

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -256,7 +256,7 @@ group_check_donor (gcs_group_t* group)
         gu_warn ("Donor %s is no longer in the group. State transfer cannot "
                  "be completed, need to abort. Aborting...", donor_id);
 
-        gu_abort();
+        // gu_abort();
     }
 
     return;


### PR DESCRIPTION
…work

  failure duing SST

  Let's understand the problem through a use-case
  * 2 node cluster with nodes n1, n2
  * 3rd node is trying to join say n3.
  * n1 is acting as DONOR and n3 is acting as JOINER
  * n1 looses n/w connectivity.
  * n2 and n3 forms a primary but n3 can't keep itself up
    in half-cooked state so it needs to leave.
  * n3 leaving should be graceful but it was abrupt shutdown
    and so n2 turns into non-primary as it loose quorum.
  * Even though n1 re-joins the cluster n1 and n2 both
    non-primary wait for n3 to come up which doesn't happen.
  * Also, as per the flow, n1 resumes original state that
    it maintained before it turned non-primary. (DONOR)
  * Since sst_sent action fails join process is not completed.

  Fix:
  ---

  * Ensure that if the sst fails on JOINER it does graceful shutdown
    (and not abrupt assert)
  * DONOR on restore should resume join state if sst_sent fails.