### PR TITLE
[BLD-725] Cannot start garbd

### DIFF
--- a/packages/debian/percona-xtradb-cluster-garbd-3.x.postinst
+++ b/packages/debian/percona-xtradb-cluster-garbd-3.x.postinst
@@ -1,0 +1,14 @@
+#!/bin/sh
+config=/etc/default/garbd
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+    if [ -x "/etc/init.d/garbd" ]; then
+        update-rc.d garbd defaults >/dev/null
+        if grep -q -E '^# REMOVE' $config; then
+            echo  "Garbd config $config is not configured yet"
+            exit 0
+        else
+                invoke-rc.d garbd start || exit $?
+        fi
+    fi
+fi
+

--- a/packages/debian/percona-xtradb-cluster-garbd-3.x.preinst
+++ b/packages/debian/percona-xtradb-cluster-garbd-3.x.preinst
@@ -5,11 +5,8 @@
 set -e
 
 if [ ! -d "/var/lib/galera" ]; then
-
-mkdir -p /var/lib/galera
-
-if id -u nobody > /dev/null 2>&1; then
+  mkdir -p /var/lib/galera
+  if id -u nobody > /dev/null 2>&1; then
     chown nobody:nogroup /var/lib/galera
-fi
-
+  fi
 fi


### PR DESCRIPTION
Setting up percona-xtradb-cluster-galera-3.x (3.20-1.zesty) ...
Setting up percona-xtradb-cluster-garbd-3.x (3.20-1.zesty) ...
Garbd config /etc/default/garbd is not configured yet
Setting up percona-xtradb-cluster-galera-3 (3.20-1.zesty) ...
Setting up percona-xtradb-cluster-garbd-3 (3.20-1.zesty) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for systemd (232-21ubuntu3) ...
ubuntu@ubuntu-zesty:~$ 

So everything works.