### PR TITLE
- PXC#835: limit wsrep_node_name to 64 bytes

### DIFF
--- a/common/wsrep_api.h
+++ b/common/wsrep_api.h
@@ -653,19 +653,19 @@ struct wsrep_stats_var
 };
 
 /*! Structure to copy-over node information exposed through PFS. */
-#define WSREP_HOSTNAME_LENGTH		128
+#define WSREP_HOSTNAME_LENGTH		64
 #define WSREP_STATUS_LENGTH		64
 
 typedef struct
 {
     /* User assigned host-name */
-    char host_name[WSREP_HOSTNAME_LENGTH];
+    char host_name[WSREP_HOSTNAME_LENGTH + 1];
 
     /* System assigned UUID */
     char uuid[WSREP_UUID_STR_LEN + 1];
 
     /* Status PRIMARY/NON_PRIMARY */
-    char status[WSREP_STATUS_LENGTH];
+    char status[WSREP_STATUS_LENGTH + 1];
 
     /* local index */
     uint64_t local_index;

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -1659,14 +1659,14 @@ gcs_group_fetch_pfs_info(
     {
         const gcs_node_t& node(group->nodes[i]);
 
-        strncpy(entries[i].host_name, node.name, sizeof(entries[i].host_name));
+        strncpy(entries[i].host_name, node.name, WSREP_HOSTNAME_LENGTH);
 
         strncpy(entries[i].uuid, node.id, WSREP_UUID_STR_LEN);
 
         strncpy(
             entries[i].status,
             gcs_node_state_to_str(node.status),
-            sizeof(entries[i].status));
+            WSREP_STATUS_LENGTH);
 
         entries[i].local_index = i;
         entries[i].segment = node.segment;


### PR DESCRIPTION
  Currently wsrep_node_name can be arbitrarily long making it difficult
  for user to grasp if someone accidentally set it to something really long.

  With introduction of pxc_cluster_view we expose this name through
  PFS table and there is limit on how long this name could be.

  In order to make all limits consistent we have opted to limit
  wsrep_node_name to 64 bytes.

  Limit of 64 bytes is inspired from the fact that gethostname()
  limits hostname to 64 bytes on linux.