### PR TITLE
Fix for PXC-810 PXC-843

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1356,6 +1356,14 @@ void galera::ReplicatorSMM::process_trx(void* recv_ctx, TrxHandle* trx)
     assert(trx->depends_seqno() == -1);
     assert(trx->state() == TrxHandle::S_REPLICATING);
 
+    // If the SST has been canceled, then ignore any other
+    // incoming transactions, as the node should be shutting down
+    if (sst_state_ == SST_CANCELED)
+    {
+        log_info << "Ignorng trx(" << trx->global_seqno() << ") due to SST failure";
+        return;
+    }
+
     wsrep_status_t const retval(cert_and_catch(trx));
 
     switch (retval)

--- a/gcs/src/gcs_gcomm.cpp
+++ b/gcs/src/gcs_gcomm.cpp
@@ -335,11 +335,18 @@ public:
         pthread_join(thd_, 0);
         {
             gcomm::Critical<Protonet> crit(*net_);
-            log_info << "gcomm: closing backend";
-            tp_->close(error_ != 0 || force == true);
-            gcomm::disconnect(tp_, this);
-            delete tp_;
-            tp_ = 0;
+            if (tp_ == 0)
+            {
+                log_info << "gcomm: backend closed already";
+            }
+            else
+            {
+                log_info << "gcomm: closing backend";
+                tp_->close(error_ != 0 || force == true);
+                gcomm::disconnect(tp_, this);
+                delete tp_;
+                tp_ = 0;
+            }
         }
         const Message* msg;
 


### PR DESCRIPTION
PXC-810: PXC 5.7: segfault in GCommConn::close in galera_var_node_address
PXC-843: Joiner hangs after failed SST

Issue:
If an SST fails due to a DML (such as OPTIMIZE or ALTER TABLE), which is run as the SST
is running, then the joiner node can hang (PXC-843).  This is due to the applier
thread picking a transaction off of the recv_q and attempting to apply it, even though
the thread has been killed.

This exposed PXC-810, which would then happen while testing for PXC-843.

Solution:
For PXC-843, if the SST has failed, then we just drop any transactions that hav
been received.  If the SST has failed, the node should be shutting down anyway.

For PXC-810, we do an additional check within the critical section to avoid the
null pointer dereference.