### PR TITLE
- PXC#850: Inconsistent behavior on data consistency abort

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -929,6 +929,13 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandle* trx, void* trx_ctx)
             log_fatal << "Failed to re-apply trx: " << *trx;
             log_fatal << e.what();
             log_fatal << "Node consistency compromized, aborting...";
+
+            /* Before doing a graceful exit ensure that node isolate itself
+            from the cluster. This will cause the quorum to re-evaluate
+            and if minority nodes are left with different set of data
+            they can turn non-Primary to avoid further data consistency issue. */
+            param_set("gmcast.isolate", "1");
+
             abort();
         }
 
@@ -1291,6 +1298,13 @@ void galera::ReplicatorSMM::process_trx(void* recv_ctx, TrxHandle* trx)
             log_fatal << "Failed to apply trx: " << *trx;
             log_fatal << e.what();
             log_fatal << "Node consistency compromized, aborting...";
+
+            /* Before doing a graceful exit ensure that node isolate itself
+            from the cluster. This will cause the quorum to re-evaluate
+            and if minority nodes are left with different set of data
+            they can turn non-Primary to avoid further data consistency issue. */
+            param_set("gmcast.isolate", "1");
+
             abort();
         }
         break;


### PR DESCRIPTION
  Problem:
  -------

  Say out of 3 node cluster, 2 nodes leave cluster due to
  data inconsistency then sole pending node should also turn
  non-Primary given that
  a. It doesn't have majority
  b. It is difficult to tell if pending node has good data
     or node that left.

  Currently, if node detects inconsistency then it leaves
  cluster gracefully and depending on timing
  sole pending node can turn non-Primary or Primary.

  Solution:
  --------

  Ensure that node leaving cluster due to data inconsistency,
  first isolate itself from cluster there-by turning non-Primary
  and forcing re-evaluation of quorum on pending nodes.

  This will ensure if minority of the nodes has inconsistent data
  and majority of the nodes are shutting down, miniority will turn non-Primary.

  (If user still would like to operate with minority nodes
   given these are writer nodes or more reliable nodes
   user can pre-adjust the pc.weight to maintain quorum).