### PR TITLE
- PXC#887: gache.page files get created unnecessarily

### DIFF
--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -1011,6 +1011,10 @@ namespace gcache
             else assert(size_trail_ >= sizeof(BufferHeader));
 
             estimate_space();
+            /* On graceful shutdown all the active buffers are released
+            so on recovery size_used_ = 0.
+            size_cache_ = size_free_ + size_used_ + releasebutnotdiscarded */
+            size_used_ = 0;
 
             /* now discard all the locked-in buffers (see seqno_reset()) */
             gu::Progress<size_t> progress(


### PR DESCRIPTION
  * gcache is used to cache the write-set is implemented using
    ringbuffer that is recycled in cyclic fashion.

  * Once all the nodes ack commit of the said write-set each node
    and process a commit-cut action there-by releasing the said
    write-set from the gcache.

    release action will mark the said entry in gcache as released
    and will also update the size_used_ as if the space is re-claimed
    though space is not yet re-claimed.

    discard action will cause the space to get re-claimed.

    This semantics of updating size_used_ during release when space
    is not yet re-claimed is cause of this bug.

  * If gcache is recovered on graceful shutdown recovery logic
    failed to considered that released entries space should not
    be considered as part of size_used_.

    It followed the normal understanding and tried to equate:
    size_cache_ = size_used_ + size_free_

    when it actually should be
    size_cache_ = size_used_ (real active non-released entry)
                  + size_free_ (free entry)
                  + release_but_not_discarded
    where release_but_not_discarded accomodate all such entries for which
    entry has been released but space is not yet re-claimed.

    Corrected recovery protocol to match the normal working
    protocol.