### PR TITLE
- PXC#737: Freezeing gcache purge to facilitate node joining

### DIFF
--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -211,10 +211,17 @@ namespace gcache
             size_t keep_pages_count()    const { return keep_pages_count_; }
             bool   recover()             const { return recover_;         }
 
+            bool skip_purge(seqno_t seqno)
+            {
+                return ((freeze_purge_at_seqno_ == SEQNO_ILL)
+                        ? (false) : (seqno >= freeze_purge_at_seqno_));
+            }
+
             void mem_size         (size_t s) { mem_size_         = s; }
             void page_size        (size_t s) { page_size_        = s; }
             void keep_pages_size  (size_t s) { keep_pages_size_  = s; }
             void keep_pages_count (size_t c) { keep_pages_count_ = c; }
+            void freeze_purge_at_seqno(seqno_t s) { freeze_purge_at_seqno_ = s; }
 
         private:
 
@@ -226,6 +233,7 @@ namespace gcache
             size_t            keep_pages_size_;
             size_t            keep_pages_count_;
             bool        const recover_;
+            seqno_t           freeze_purge_at_seqno_;
         }
             params;
 

--- a/gcache/src/GCache_memops.cpp
+++ b/gcache/src/GCache_memops.cpp
@@ -14,6 +14,10 @@ namespace gcache
         for (seqno2ptr_t::iterator i = seqno2ptr.begin();
              i != seqno2ptr.end() && i->first <= seqno;)
         {
+            /* Skip purge from this seqno onwards. */
+            if (params.skip_purge(i->first))
+                return false;
+
             BufferHeader* bh(ptr2BH (i->second));
 
             if (gu_likely(BH_is_released(bh)))

--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -65,6 +65,7 @@ namespace gcache
                     sizeof(BufferHeader)),
         seqno2ptr_ (seqno2ptr),
         gid_       (gid),
+        freeze_purge_at_seqno_(SEQNO_ILL),
         size_cache_(end_ - start_ - sizeof(BufferHeader)),
         size_free_ (size_cache_),
         size_used_ (0),
@@ -104,6 +105,10 @@ namespace gcache
     {
         for (seqno2ptr_t::iterator i(i_begin); i != i_end;)
         {
+            /* Skip purge from this seqno onwards. */
+            if (skip_purge(i->first))
+                return false;
+
             seqno2ptr_t::iterator j(i); ++i;
             BufferHeader* const bh (ptr2BH (j->second));
 

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -113,6 +113,17 @@ namespace gcache
 
         size_t allocated_pool_size ();
 
+        void set_freeze_purge_at_seqno(seqno_t seqno)
+        {
+            freeze_purge_at_seqno_ = seqno;
+        }
+
+        bool skip_purge(seqno_t seqno)
+        {
+            return ((freeze_purge_at_seqno_ == SEQNO_ILL)
+                    ? (false) : (seqno >= freeze_purge_at_seqno_));
+        }
+
     private:
 
         static size_t const PREAMBLE_LEN = 1024;
@@ -130,6 +141,8 @@ namespace gcache
         size_t            max_used_; // maximal memory usage (in bytes)
         seqno2ptr_t&       seqno2ptr_;
         gu::UUID&          gid_;
+
+        seqno_t            freeze_purge_at_seqno_;
 
         size_t       const size_cache_;
         size_t             size_free_;

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -1190,7 +1190,8 @@ group_find_ist_donor (const gcs_group_t* const group,
 
     if (ist_seqno < safe_ist_seqno) {
         // unsafe to perform ist.
-        gu_debug("fallback to sst. ist_seqno < safe_ist_seqno");
+        gu_info("may fallback to sst. ist_seqno [%lld] < safe_ist_seqno [%lld]",
+                (long long) ist_seqno, (long long) safe_ist_seqno);
         return -1;
     }
 


### PR DESCRIPTION
  through IST

  * Currently if an existing node of the cluster is taken down
    for short period of time (say for maintenance) rejoining
    of the node through IST depends on whether the existing
    nodes of the cluster retain the data.

  * Based on historical patterns, tools like PMM can help
    user predict how long user can keep the node out of cluster
    without need for SST but this is rough estimate only.
    Also, what is the time is too short for maintenance.

  * Most of the time user kick-start cluster with
    default gcache and later discovers need for larger gcache.
    While larger gcache is possible it demands restart of the node.
    (dyanmic gcache resizing it not possible or not needed I would say).

  * What if there is facility using which user can freeze
    purging of gcache for the said node so that when the node
    re-joins it always joins through IST.

  This patch solves the said problem.
  We are introducing a facility called freeze gcache purge.
  User can freeze gcache purge there-by enabling retention of
  the write-sets. Just freeze the gcache before taking down the node
  and once node is back unfreeze the gcache.

  Proposed alternative is controlled using a param called
  gcache.freeze_purge_at_seqno.

  * -1 (default):
    - Ignore freezing

  * x (write-set with x seqno should be present in gcache)
    - Stop purging of write-set >= x

  * now
    - Set the freezing point to smallest seqno in gcache.

  ---------------

  Say user wants to shutdown node-3 then user can set the
  said param to "now" or "x" on node-1 or node-2.

  Guideline:
  - x is point till which (in form of seqno) node-3 has applied write-set.

  If finding x is time-taking simply set it to "now".

  Remember to reset it back to -1 once done else the freezing continues
  and disk space continue to get filled up.