### PR TITLE
PXC-911 : "no messages seen in" from itself when starting

### DIFF
--- a/gcomm/src/gmcast.cpp
+++ b/gcomm/src/gmcast.cpp
@@ -1085,11 +1085,15 @@ void gcomm::GMCast::check_liveness()
             p->state() < Proto::S_FAILED &&
             p->tstamp() + peer_timeout_ < now)
         {
-            log_info << self_string()
-                     << " connection to peer "
-                     << p->remote_uuid() << " with addr "
-                     << p->remote_addr()
-                     << " timed out, no messages seen in " << peer_timeout_;
+            // Only log if addr has not been blacklisted
+            if (addr_blacklist_.find(p->remote_addr()) == addr_blacklist_.end())
+            {
+                log_info << self_string()
+                         << " connection to peer "
+                         << p->remote_uuid() << " with addr "
+                         << p->remote_addr()
+                         << " timed out, no messages seen in " << peer_timeout_;
+            }
             p->set_state(Proto::S_FAILED);
             handle_failed(p);
         }


### PR DESCRIPTION
Issue:
A message is set to the info log when no messages are received from a node
for a certain timeout.  However, in this case, the address has been
blacklisted since it's coming from itself.  Becasue it's blacklisted,
we would not expect to hear from that address anymore.

Solution
Only log the message if the node is NOT blacklisted.