### PR TITLE
PXC-2061 : PXC 5.7: wsrep_sync_wait not working

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1133,14 +1133,9 @@ wsrep_status_t galera::ReplicatorSMM::causal_read(wsrep_gtid_t* gtid)
         // finished.
         gu::datetime::Date wait_until(gu::datetime::Date::calendar()
                                       + causal_read_timeout_);
-        if (gu_likely(co_mode_ != CommitOrder::BYPASS))
-        {
-            commit_monitor_.wait(cseq, wait_until);
-        }
-        else
-        {
-            apply_monitor_.wait(cseq, wait_until);
-        }
+
+        apply_monitor_.wait(cseq, wait_until);
+
         if (gtid != 0)
         {
             gtid->uuid = state_uuid_;


### PR DESCRIPTION
Issue:
When "wsrep_sync_wait=1", which enforces read causality, we can read
the wrong values, depending on timing. This happens because we are
waiting on the commit monitor to be flushed.

Solution:
We need to wait upon the apply monitor instead of the commit monitor.