### PR TITLE
- PXC#2273: Improve log message about gcache purge

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -1030,12 +1030,16 @@ galera::Certification::purge_trxs_upto_(wsrep_seqno_t const seqno,
 
     TrxMap::iterator purge_bound(trx_map_.upper_bound(seqno));
 
-    cert_debug << "purging index up to " << seqno;
+    log_debug << "purging index up to " << seqno;
 
     for_each(trx_map_.begin(), purge_bound, PurgeAndDiscard(*this));
     trx_map_.erase(trx_map_.begin(), purge_bound);
 
-    if (handle_gcache) service_thd_.release_seqno(seqno);
+    if (handle_gcache)
+    {
+        log_debug << "releasing seqno from gcache " << seqno;
+        service_thd_.release_seqno(seqno);
+    }
 
     if (0 == ((trx_map_.size() + 1) % 10000))
     {


### PR DESCRIPTION
  - Currently when purge takes place or when seqno is released
    these messages are not emitted using normal debug flow.

  - These messages are important to understand gcache purging.
    Enable them to get emitted when user turn off galera debug mode.