### PR TITLE
- PXC#2407: Expose galera (local/apply/commit) monitor stats as part …

### DIFF
--- a/galera/src/monitor.hpp
+++ b/galera/src/monitor.hpp
@@ -239,6 +239,15 @@ namespace galera
             gu::Lock lock(mutex_);
             return last_left_;
         }
+
+        void stats(std::vector<wsrep_seqno_t>& vc)   const
+        {
+            gu::Lock lock(mutex_);
+            vc.push_back(entered_);
+            vc.push_back(last_entered_);
+            vc.push_back(last_left_);
+        }
+
         ssize_t       size()        const { return process_size_; }
 
         bool would_block (wsrep_seqno_t seqno) const

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -474,6 +474,8 @@ void galera::ReplicatorSMM::apply_trx(void* recv_ctx, TrxHandle* trx)
     assert(trx->global_seqno() > STATE_SEQNO());
     assert(trx->is_local() == false);
 
+    GU_DBUG_SYNC_WAIT("sync.apply_trx.start_of_apply_trx");
+
     ApplyOrder ao(*trx);
     CommitOrder co(*trx, co_mode_);
 
@@ -1403,7 +1405,7 @@ void galera::ReplicatorSMM::process_trx(void* recv_ctx, TrxHandle* trx)
     // incoming transactions, as the node should be shutting down
     if (sst_state_ == SST_CANCELED)
     {
-        log_info << "Ignorng trx(" << trx->global_seqno() << ") due to SST failure";
+        log_info << "Ignoring trx(" << trx->global_seqno() << ") due to SST failure";
         return;
     }
 

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -674,6 +674,7 @@ namespace galera
         // Storage space for dynamic status strings
         char                  interval_string_[64];
         char                  ist_status_string_[128];
+        char                  monitor_status_string_[1024];
     };
 
     std::ostream& operator<<(std::ostream& os, ReplicatorSMM::State state);


### PR DESCRIPTION
…of show status

  - Galera has concept of monitor. Monitor maintains a queue (FIFO)
    and transaction are processed as per this order.

  - Some queue allow parallel processing. Like transaction in apply queue
    can be applied in parallel but commit queue/monitor should be applied
    striclty one-after-another.

  - Getting stats of this queue/monitor can help get important insight
    to understand how galera is processing transaction.