### PR TITLE
Fix build galera with std::shared_ptr

### DIFF
--- a/galera/src/wsdb.cpp
+++ b/galera/src/wsdb.cpp
@@ -9,6 +9,7 @@
 #include "gu_lock.hpp"
 #include "gu_throw.hpp"
 
+#include <algorithm> // std::for_each
 
 void galera::Wsdb::print(std::ostream& os) const
 {


### PR DESCRIPTION
Default scons configuration provides '-ansi' flag to g++ compiler, which
actually means '-std=c++98'. So, later tests for c++11 features always
fails and build finaly is always based on TR1/Boost implementations.

Rewriting this flag to '-std=c++11' effectively invokes std library
instead, but galera then fails to build because of using `for_each`
without explicitly included <algorithm> (it seems that boost shared_ptr
replacement uses it for own purposes, and pollutes global scope).