### PR TITLE
PXC-3076: Galera build doesn't work with Python 3 (5.7)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -202,14 +202,6 @@ if link != 'default':
 cc_version = str(read_first_line(env['CC'].split() + ['--version']))
 cxx_version = str(read_first_line(env['CXX'].split() + ['--version']))
 
-if python_ver >= 3:
-    cc_version = cc_version.decode()
-    cxx_version = cxx_version.decode()
-
-if python_ver >= 3:
-    cc_version = cc_version.decode()
-    cxx_version = cxx_version.decode()
-
 print('Using C compiler executable: ' + env['CC'])
 print('C compiler version is: ' + cc_version)
 print('Using C++ compiler executable: ' + env['CXX'])


### PR DESCRIPTION
Hello,

raising a PR since there is no way to raise an issue. I was trying to build garbd on python 3.5.2 and got the error with .decode() function missing in py3. Fixed by removing the condition. 

Apart from that, somehow the condition got in twice (looks like possibly due to conflict resolution on merging?)...