### PR TITLE
- PXC-2946: bootstrapping node fails to set gtid in gcache

### DIFF
--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -61,7 +61,7 @@ namespace gcache
          * Reinitialize seqno sequence (after SST or such)
          * Clears seqno->ptr map // and sets seqno_min to seqno.
          */
-        void seqno_reset (const gu::GTID& gtid);
+        void seqno_reset (const gu::GTID& gtid, bool zero_out = false);
 
         /*!
          * Assign sequence number to buffer pointed to by ptr

--- a/gcache/src/GCache_seqno.cpp
+++ b/gcache/src/GCache_seqno.cpp
@@ -16,7 +16,7 @@ namespace gcache
      * Clears seqno->ptr map in case of history gap (after SST or such).
      */
     void
-    GCache::seqno_reset (const gu::GTID& gtid)
+    GCache::seqno_reset (const gu::GTID& gtid, bool zero_out)
     {
         gu::Lock lock(mtx);
 
@@ -41,7 +41,7 @@ namespace gcache
         gid = gtid.uuid();
 
         /* order is significant here */
-        rb.seqno_reset();
+        rb.seqno_reset(zero_out);
         mem.seqno_reset();
 
         seqno2ptr.clear();

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -69,7 +69,7 @@ namespace gcache
 
         void  reset();
 
-        void  seqno_reset();
+        void  seqno_reset(bool zero_out = false);
 
         /* returns true when successfully discards all seqnos in range */
         bool  discard_seqnos(seqno2ptr_t::iterator i_begin,
@@ -202,7 +202,7 @@ namespace gcache
         int64_t       scan(off_t offset, int scan_step);
         void          recover(off_t offset, int version);
 
-        void          estimate_space();
+        void          estimate_space(bool zero_out = false);
 
         RingBuffer(const gcache::RingBuffer&);
         RingBuffer& operator=(const gcache::RingBuffer&);


### PR DESCRIPTION
  - There are multiple problem fixed as part of this issue

  Issue-1:
  --------

  * If node is started fresh using seed-db that means it doesn't have
    pre-existing gcache it initialized gcache with empty/null sequence number.
    Given the said gcache will be used to append write-set cluster-id
    should be valid. (This was regression in 8.x as it is present in 5.7)

  Issue-2:
  -------

  * Say node-2 is shutdown and restarted it would result in IST and node-2
    is able to join by taking over missing write-sets from node-1 (DONOR).

  * If post node-2 is shutdown if node-1 is shutdown too and restarted
    before node-2, node-2 restart sequence use to result in error.
    This error arised from the fact that node-2 CC event failed to wait
    node-2 to process missing write-sets it has receieved through IST.
    Same case is not a problem if node-1 is not restarted because then
    node-1 while donating these write-sets mark them with preload option
    that causes node-2 to append these write-sets to cert queue
    (to restore/recreate the queue). append_trx will then increment
    needed monitor so by the time node-2 is ready to process CC
    monitor position is correctly set.

  Issue-3:
  --------

  * Say completely cluster is abruptly killed when it rejoins is it possible
    that one of the node has more processed transaction than other nodes
    (these transaction where in other node incoming queue but not yet applied).

  * On restart, given pc.recovery=yes will cause complete cluster to recover.
    In this case node that has missing write-sets try to get it from
    one of the existing node and in turn get its own missing write-sets event
    self-delivered as part of IST for apply. Kind of recursive loop.

  * This condition is detected and handled.