### PR TITLE
PXC-2972: Handle too long writesets in debug builds

### DIFF
--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -1142,9 +1142,7 @@ wsrep_status_t galera_to_execute_start(wsrep_t*                const gh,
 
     wsrep_status_t retval;
 
-#ifdef NDEBUG
     try
-#endif // NDEBUG
     {
         TrxHandleLock lock(trx);
         for (size_t i(0); i < keys_num; ++i)
@@ -1190,7 +1188,6 @@ wsrep_status_t galera_to_execute_start(wsrep_t*                const gh,
             retval = repl->to_isolation_begin(trx, meta);
         }
     }
-#ifdef NDEBUG
     catch (gu::Exception& e)
     {
         log_error << e.what();
@@ -1210,7 +1207,6 @@ wsrep_status_t galera_to_execute_start(wsrep_t*                const gh,
         log_fatal << "non-standard exception";
         retval = WSREP_FATAL;
     }
-#endif // NDEBUG
 
     if (trx.ts() == NULL || trx.ts()->global_seqno() < 0)
     {


### PR DESCRIPTION
Issue: excpetion handlers around writeset buffer overflows were only
built for release builds. Writeset exceptions thrown in debug builds
caused the server to crash.

Fix: removed the NDEBUG ifdefs.