### PR TITLE
PXC-2908 : Print proper error message if pxc_encrypt_cluster_traffic …

### DIFF
--- a/gcomm/src/asio_tcp.cpp
+++ b/gcomm/src/asio_tcp.cpp
@@ -69,10 +69,15 @@ void gcomm::AsioTcpSocket::handshake_handler(const asio::error_code& ec)
             gu::exclude_ssl_error(ec) == false)
         {
 
-            log_error << "handshake with remote endpoint "
-                      << remote_addr() << " failed: " << ec << ": '"
-                      << ec.message()
-                      << "' ( " << gu::extra_error_info(ec) << ")";
+            log_error
+                << "handshake with remote endpoint "
+                << remote_addr() << " failed: " << ec << ": '"
+                << ec.message()
+                << "' ( " << gu::extra_error_info(ec) << ")" << std::endl
+                << "This error is often caused by SSL issues. "
+                << "For more information, please see:" << std::endl
+                << "  https://per.co.na/pxc/encrypt_cluster_traffic" << std::endl
+                << "--------";
         }
         FAILED_HANDLER(ec);
         return;


### PR DESCRIPTION
…is ON and SSL certificates are missing/not matching in the default configuration.

Issue
The error messages, due to a mismatch in SSL configuration, are not very clear or helpful.
This is more important with PXC 8.0 due to the SSL-encryption for all cluster
traffic is now enabled by default:

Solution
Enhance the error text when an SSL is encountered when joining the cluster.
We now display a link to the docs.