### PR TITLE
PXC-3044: IST is failing with PXC-8.0 upgrade

### DIFF
--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -1071,7 +1071,12 @@ ReplicatorSMM::request_state_transfer (void* recv_ctx,
                  and commit_monitor_ are initialized with N which causes infinite
                  wait in commit_monitor_ when node joins cluster at GCS level
                  at the end of processing GCS_ACT_CCHANGE. */
-            if (str_proto_ver_ < 3 && sst_seqno_ < cc_seqno) {
+            log_info << " str_proto_ver_: " << str_proto_ver_
+                     << " sst_seqno_: " << sst_seqno_
+                     << " cc_seqno: " << cc_seqno
+                     << " req->ist_len(): " << req->ist_len();
+            if (str_proto_ver_ < 3 && sst_seqno_ < cc_seqno &&
+                req->ist_len() == 0 ) {
                 log_warn << "Seqno received from SST is in the past. "
                          << "It should be equal to or greater than seqno received from cluster "
                          << "but this may happen if the node joins PXC 5.7 cluster. "


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3044

Prevented workaround for wrong sst_seqno (PXC-3001) if IST is on the way.

Case:
1. Cluster consisting of 1 x 5.7 + 2 x 8.0 nodes
2. On of 8.0 nodes goes down
3. Cluster state goes forward (some inserts done on 5.7 node, replicated to online 8.0 node)
4. 8.0 node that was down is rejoining. IST is expected to be done, sst communication protocol < 3 as we have 5.7 node in the cluster even if donor and joiner are 8.0