### PR TITLE
PXC-3069: Fixing std::vector assertions

### DIFF
--- a/asio/asio/basic_socket_streambuf.hpp
+++ b/asio/asio/basic_socket_streambuf.hpp
@@ -388,7 +388,7 @@ protected:
 
         buffer = buffer + bytes_transferred_;
       }
-      setp(&put_buffer_[0], &put_buffer_[0] + put_buffer_.size());
+      setp(put_buffer_.data(), put_buffer_.data() + put_buffer_.size());
 
       // If the new character is eof then our work here is done.
       if (traits_type::eq_int_type(c, traits_type::eof()))
@@ -437,7 +437,7 @@ private:
     if (unbuffered_)
       setp(0, 0);
     else
-      setp(&put_buffer_[0], &put_buffer_[0] + put_buffer_.size());
+      setp(put_buffer_.data(), put_buffer_.data() + put_buffer_.size());
   }
 
   template <typename ResolverQuery>

--- a/asio/asio/impl/error_code.ipp
+++ b/asio/asio/impl/error_code.ipp
@@ -50,7 +50,7 @@ public:
     {
       DWORD wlength = ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM
           | FORMAT_MESSAGE_IGNORE_INSERTS, 0, value,
-          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), &wmsg[0], wmsg.size(), 0);
+          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), wmsg.data(), wmsg.size(), 0);
       if (wlength == 0 && ::GetLastError() == ERROR_INSUFFICIENT_BUFFER)
       {
         wmsg.resize(wmsg.size() + wmsg.size() / 2);

--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -595,7 +595,7 @@ galera::NBOEntry copy_ts(
         gu_throw_error(ERANGE) << "Buffer size " << buf->size()
                                << " out of range";
     gcs_action act = {ts->global_seqno(), ts->local_seqno(),
-                      &(*buf)[0], static_cast<int32_t>(buf->size()),
+                      buf->data(), static_cast<int32_t>(buf->size()),
                       GCS_ACT_WRITESET};
     if (ts->certified() == false)
     {

--- a/galera/src/ist_proto.hpp
+++ b/galera/src/ist_proto.hpp
@@ -305,8 +305,8 @@ namespace galera
             {
                 Handshake  hs(version_);
                 gu::Buffer buf(hs.serial_size());
-                size_t offset(hs.serialize(&buf[0], buf.size(), 0));
-                size_t n(asio::write(socket, asio::buffer(&buf[0],
+                size_t offset(hs.serialize(buf.data(), buf.size(), 0));
+                size_t n(asio::write(socket, asio::buffer(buf.data(),
                                                           buf.size())));
                 if (n != offset)
                 {
@@ -319,14 +319,14 @@ namespace galera
             {
                 Message    msg(version_);
                 gu::Buffer buf(msg.serial_size());
-                size_t n(asio::read(socket, asio::buffer(&buf[0], buf.size())));
+                size_t n(asio::read(socket, asio::buffer(buf.data(), buf.size())));
 
                 if (n != buf.size())
                 {
                     gu_throw_error(EPROTO) << "error receiving handshake";
                 }
 
-                (void)msg.unserialize(&buf[0], buf.size(), 0);
+                (void)msg.unserialize(buf.data(), buf.size(), 0);
 
                 log_debug << "handshake msg: " << msg.version() << " "
                           << msg.type() << " " << msg.len();
@@ -364,8 +364,8 @@ namespace galera
             {
                 HandshakeResponse hsr(version_);
                 gu::Buffer buf(hsr.serial_size());
-                size_t offset(hsr.serialize(&buf[0], buf.size(), 0));
-                size_t n(asio::write(socket, asio::buffer(&buf[0], buf.size())));
+                size_t offset(hsr.serialize(buf.data(), buf.size(), 0));
+                size_t n(asio::write(socket, asio::buffer(buf.data(), buf.size())));
                 if (n != offset)
                 {
                     gu_throw_error(EPROTO)
@@ -378,14 +378,14 @@ namespace galera
             {
                 Message    msg(version_);
                 gu::Buffer buf(msg.serial_size());
-                size_t n(asio::read(socket, asio::buffer(&buf[0], buf.size())));
+                size_t n(asio::read(socket, asio::buffer(buf.data(), buf.size())));
 
                 if (n != buf.size())
                 {
                     gu_throw_error(EPROTO) << "error receiving handshake";
                 }
 
-                (void)msg.unserialize(&buf[0], buf.size(), 0);
+                (void)msg.unserialize(buf.data(), buf.size(), 0);
 
                 log_debug << "handshake response msg: " << msg.version()
                           << " " << msg.type()
@@ -415,8 +415,8 @@ namespace galera
             {
                 Ctrl       ctrl(version_, code);
                 gu::Buffer buf(ctrl.serial_size());
-                size_t offset(ctrl.serialize(&buf[0], buf.size(), 0));
-                size_t n(asio::write(socket, asio::buffer(&buf[0],buf.size())));
+                size_t offset(ctrl.serialize(buf.data(), buf.size(), 0));
+                size_t n(asio::write(socket, asio::buffer(buf.data(),buf.size())));
                 if (n != offset)
                 {
                     gu_throw_error(EPROTO) << "error sending ctrl message";
@@ -428,14 +428,14 @@ namespace galera
             {
                 Message    msg(version_);
                 gu::Buffer buf(msg.serial_size());
-                size_t n(asio::read(socket, asio::buffer(&buf[0], buf.size())));
+                size_t n(asio::read(socket, asio::buffer(buf.data(), buf.size())));
 
                 if (n != buf.size())
                 {
                     gu_throw_error(EPROTO) << "error receiving handshake";
                 }
 
-                (void)msg.unserialize(&buf[0], buf.size(), 0);
+                (void)msg.unserialize(buf.data(), buf.size(), 0);
 
                 log_debug << "msg: " << msg.version() << " " << msg.type()
                           << " " << msg.len();
@@ -526,17 +526,17 @@ namespace galera
                                trx_meta_size + payload_size, buffer.seqno_g());
 
                 gu::Buffer buf(to_msg.serial_size() + trx_meta_size);
-                size_t  offset(to_msg.serialize(&buf[0], buf.size(), 0));
+                size_t  offset(to_msg.serialize(buf.data(), buf.size(), 0));
 
                 if (gu_unlikely(version_ < VER40))
                 {
                     offset = gu::serialize8(buffer.seqno_g(),
-                                            &buf[0], buf.size(), offset);
+                                            buf.data(), buf.size(), offset);
                     offset = gu::serialize8(seqno_d,
-                                            &buf[0], buf.size(), offset);
+                                            buf.data(), buf.size(), offset);
                 }
 
-                cbs[0] = asio::const_buffer(&buf[0], buf.size());
+                cbs[0] = asio::const_buffer(buf.data(), buf.size());
 
                 if (gu_likely(payload_size))
                 {
@@ -558,7 +558,7 @@ namespace galera
                 {
                     bytes -= asio::read(
                         socket,
-                        asio::buffer(&buf[0], std::min(buf.size(), bytes)));
+                        asio::buffer(buf.data(), std::min(buf.size(), bytes)));
                 }
                 assert(bytes == 0);
             }
@@ -579,14 +579,14 @@ namespace galera
 
                 Message    msg(version_);
                 gu::Buffer buf(msg.serial_size());
-                size_t n(asio::read(socket, asio::buffer(&buf[0], buf.size())));
+                size_t n(asio::read(socket, asio::buffer(buf.data(), buf.size())));
 
                 if (n != buf.size())
                 {
                     gu_throw_error(EPROTO) << "error receiving trx header";
                 }
 
-                (void)msg.unserialize(&buf[0], buf.size(), 0);
+                (void)msg.unserialize(buf.data(), buf.size(), 0);
 
                 log_debug << "received header: " << n << " bytes, type "
                           << msg.type() << " len " << msg.len();
@@ -608,7 +608,7 @@ namespace galera
 
                         buf.resize(sizeof(seqno_g) + sizeof(seqno_d));
 
-                        n = asio::read(socket, asio::buffer(&buf[0],buf.size()));
+                        n = asio::read(socket, asio::buffer(buf.data(),buf.size()));
                         if (n != buf.size())
                         {
                             assert(0);
@@ -616,7 +616,7 @@ namespace galera
                                 << "error reading trx meta data";
                         }
 
-                        offset = gu::unserialize8(&buf[0],buf.size(),0,seqno_g);
+                        offset = gu::unserialize8(buf.data(),buf.size(),0,seqno_g);
                         if (gu_unlikely(seqno_g <= 0))
                         {
                             assert(0);
@@ -624,7 +624,7 @@ namespace galera
                                 << "non-positive sequence number " << seqno_g;
                         }
 
-                        offset = gu::unserialize8(&buf[0], buf.size(), offset,
+                        offset = gu::unserialize8(buf.data(), buf.size(), offset,
                                                   seqno_d);
                         if (gu_unlikely(seqno_d == WSREP_SEQNO_UNDEFINED &&
                                         offset != msg.len()))

--- a/galera/src/key_os.hpp
+++ b/galera/src/key_os.hpp
@@ -131,7 +131,7 @@ namespace galera
                     size_t len_size(gu::uleb128_size(key_len));
                     keys_.resize(offset + len_size);
                     (void)gu::uleb128_encode(
-                        key_len, &keys_[0], keys_.size(), offset);
+                        key_len, keys_.data(), keys_.size(), offset);
                     keys_.insert(keys_.end(), base, base + keys[i].key_len);
 #endif
                 }
@@ -169,7 +169,7 @@ namespace galera
 #else
                 size_t key_len;
                 size_t offset(
-                    gu::uleb128_decode(&keys_[0], keys_size, i, key_len));
+                    gu::uleb128_decode(keys_.data(), keys_size, i, key_len));
                 key_len += offset - i;
 #endif
                 if (gu_unlikely((i + key_len) > keys_size))
@@ -209,7 +209,7 @@ namespace galera
 
         size_t hash() const
         {
-            return gu_table_hash(&keys_[0], keys_.size());
+            return gu_table_hash(keys_.data(), keys_.size());
         }
 
         size_t hash_with_flags() const
@@ -268,7 +268,7 @@ namespace galera
             size_t keys_size(keys_.size());
             offset = gu::uleb128_encode(keys_size, buf, buflen, offset);
             assert (offset + key_size <= buflen);
-            std::copy(&keys_[0], &keys_[0] + keys_size, buf + offset);
+            std::copy(keys_.data(), keys_.data() + keys_size, buf + offset);
             return (offset + keys_size);
         }
 #endif

--- a/galera/src/mapped_buffer.hpp
+++ b/galera/src/mapped_buffer.hpp
@@ -41,6 +41,9 @@ namespace galera
         const_iterator begin() const { return buf_; }
         const_iterator end()   const { return (buf_ + buf_size_); }
 
+        iterator data()  noexcept { return buf_; }
+        const_iterator data() const noexcept { return buf_; }
+
     private:
 
         MappedBuffer(const MappedBuffer&);

--- a/galera/src/write_set.cpp
+++ b/galera/src/write_set.cpp
@@ -96,7 +96,7 @@ void galera::WriteSet::append_key(const KeyData& kd)
     {
         KeyOS cmp(version_);
 
-        (void)cmp.unserialize(&keys_[0], keys_.size(), i->second);
+        (void)cmp.unserialize(keys_.data(), keys_.size(), i->second);
 
         if (key == cmp && key.flags() == cmp.flags()) return;
     }
@@ -104,7 +104,7 @@ void galera::WriteSet::append_key(const KeyData& kd)
     size_t key_size(key.serial_size());
     size_t offset(keys_.size());
     keys_.resize(offset + key_size);
-    (void)key.serialize(&keys_[0], keys_.size(), offset);
+    (void)key.serialize(keys_.data(), keys_.size(), offset);
     (void)key_refs_.insert(std::make_pair(hash, offset));
 }
 
@@ -115,7 +115,7 @@ void galera::WriteSet::get_keys(KeySequence& s) const
     while (offset < keys_.size())
     {
         KeyOS key(version_);
-        if ((offset = key.unserialize(&keys_[0], keys_.size(), offset)) == 0)
+        if ((offset = key.unserialize(keys_.data(), keys_.size(), offset)) == 0)
         {
             gu_throw_fatal << "failed to unserialize key";
         }

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -1121,8 +1121,8 @@ wsrep_status_t galera_to_execute_start(wsrep_t*                const gh,
     {
         galera::NBOKey key(meta->gtid.seqno);
         gu::Buffer buf(galera::NBOKey::serial_size());
-        (void)key.serialize(&buf[0], buf.size(), 0);
-        struct wsrep_buf data_buf = {&buf[0], buf.size()};
+        (void)key.serialize(buf.data(), buf.size(), 0);
+        struct wsrep_buf data_buf = {buf.data(), buf.size()};
         gu_trace(append_data_array(trx, &data_buf, 1, WSREP_DATA_ORDERED,true));
     }
 

--- a/gcomm/src/asio_tcp.cpp
+++ b/gcomm/src/asio_tcp.cpp
@@ -307,7 +307,7 @@ void gcomm::AsioTcpSocket::write_handler(const asio::error_code& ec,
                 cbs[0] = asio::const_buffer(dg.header()
                                             + dg.header_offset(),
                                             dg.header_len());
-                cbs[1] = asio::const_buffer(&dg.payload()[0],
+                cbs[1] = asio::const_buffer(dg.payload().data(),
                                             dg.payload().size());
                 write_one(cbs);
             }
@@ -372,7 +372,7 @@ namespace gcomm
                 cbs[0] = asio::const_buffer(dg.header()
                                             + dg.header_offset(),
                                             dg.header_len());
-                cbs[1] = asio::const_buffer(&dg.payload()[0],
+                cbs[1] = asio::const_buffer(dg.payload().data(),
                                             dg.payload().size());
                 socket_->write_one(cbs);
             }
@@ -447,7 +447,7 @@ void gcomm::AsioTcpSocket::read_handler(const asio::error_code& ec,
         NetHeader hdr;
         try
         {
-            unserialize(&recv_buf_[0], recv_buf_.size(), 0, hdr);
+            unserialize(recv_buf_.data(), recv_buf_.size(), 0, hdr);
         }
         catch (gu::Exception& e)
         {
@@ -563,7 +563,7 @@ void gcomm::AsioTcpSocket::async_receive()
 
     gu::array<asio::mutable_buffer, 1>::type mbs;
 
-    mbs[0] = asio::mutable_buffer(&recv_buf_[0], recv_buf_.size());
+    mbs[0] = asio::mutable_buffer(recv_buf_.data(), recv_buf_.size());
     read_one(mbs);
 }
 

--- a/gcomm/src/asio_udp.cpp
+++ b/gcomm/src/asio_udp.cpp
@@ -147,7 +147,7 @@ int gcomm::AsioUdpSocket::send(const Datagram& dg)
     cbs[0] = asio::const_buffer(buf, sizeof(buf));
     cbs[1] = asio::const_buffer(dg.header() + dg.header_offset(),
                           dg.header_len());
-    cbs[2] = asio::const_buffer(&dg.payload()[0], dg.payload().size());
+    cbs[2] = asio::const_buffer(dg.payload().data(), dg.payload().size());
     try
     {
         socket_.send_to(cbs, target_ep_);
@@ -220,7 +220,7 @@ void gcomm::AsioUdpSocket::async_receive()
 {
     Critical<AsioProtonet> crit(net_);
     gu::array<asio::mutable_buffer, 1>::type mbs;
-    mbs[0] = asio::mutable_buffer(&recv_buf_[0], recv_buf_.size());
+    mbs[0] = asio::mutable_buffer(recv_buf_.data(), recv_buf_.size());
     socket_.async_receive_from(mbs, source_ep_,
                                boost::bind(&AsioUdpSocket::read_handler,
                                            shared_from_this(),

--- a/gcomm/src/datagram.cpp
+++ b/gcomm/src/datagram.cpp
@@ -58,8 +58,8 @@ gcomm::crc16(const gcomm::Datagram& dg, size_t offset)
         offset -= dg.header_len();
     }
 
-    crc.process_block(&(*dg.payload_)[0] + offset,
-                      &(*dg.payload_)[0] + dg.payload_->size());
+    crc.process_block(dg.payload_->data() + offset,
+                      dg.payload_->data() + dg.payload_->size());
 
     return crc.checksum();
 }
@@ -91,8 +91,8 @@ gcomm::crc32(gcomm::NetHeader::checksum_t const type,
             offset -= dg.header_len();
         }
 
-        crc.process_block(&(*dg.payload_)[0] + offset,
-                          &(*dg.payload_)[0] + dg.payload_->size());
+        crc.process_block(dg.payload_->data() + offset,
+                          dg.payload_->data() + dg.payload_->size());
 
         return crc.checksum();
     }
@@ -113,7 +113,7 @@ gcomm::crc32(gcomm::NetHeader::checksum_t const type,
             offset -= dg.header_len();
         }
 
-        crc.append (&(*dg.payload_)[0] + offset, dg.payload_->size() - offset);
+        crc.append (dg.payload_->data() + offset, dg.payload_->size() - offset);
 
         return crc();
     }

--- a/gcomm/src/gcomm/util.hpp
+++ b/gcomm/src/gcomm/util.hpp
@@ -38,7 +38,7 @@ namespace gcomm
         const size_t prev_size(buf.size());
         buf.resize(buf.size() + c.serial_size());
         size_t ret;
-        gu_trace(ret = c.serialize(&buf[0] + prev_size, buf.size(),
+        gu_trace(ret = c.serialize(buf.data() + prev_size, buf.size(),
                                    prev_size));
         assert(ret == prev_size + c.serial_size());
         return ret;


### PR DESCRIPTION
Issue: accessing the address of the first element of an empty vector is
UB, and this is a repeated pattern in galera. This results in crashes
with the centos 8 build.

Fix: changed all uses of [0] to .data() where it makes sense, in the non
test code. Tests and code where we would crash with an empty vector
anyway were left alone.