### PR TITLE
PXC-3024: Node is unable to come up if it crashes

### DIFF
--- a/gcache/src/GCache_seqno.cpp
+++ b/gcache/src/GCache_seqno.cpp
@@ -196,6 +196,15 @@ namespace gcache
             int64_t const start(it->first - 1);
             int64_t const end  (seqno - start >= 2*batch_size ?
                                 start + batch_size : seqno);
+
+            // Just not to overcomplicate the logic here:
+            // release only if the whole batch can be released, if not - wait.
+            while(seqno_locked != SEQNO_NONE && end >= seqno_locked) {
+                log_debug << "GCache::seqno_release requested: " << seqno
+                          << " locked: " << seqno_locked << " - waiting";
+                lock.wait(cond);
+            }
+
 #ifndef NDEBUG
             if (params.debug())
             {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3024

Fixed locking of entries in gcache.

Problem:
When ST is started on Donor side, ReplicatorSMM acquires lock for gcache entries which will be served by IST sender thread (ist.cpp run_async_sender()). Then SST sender thread is started (sst_donor_thread).

When SST sender thread finishes, it calls provider's sst_sent() which causes node to rejoin the cluster. This causes cleaning up gcache entries.

The problem was that locking of gcache entries didn't work at all. It was fixed.

We can see this problem also as side effect of upstream commit aa6e9fe33be2d8d7dd56c3e20f50eee326264acc (Refs #782 workaround in ReplicatorSMM::process_commit_cut) which causes purging of gcache items in the response of finished SST.