### PR TITLE
PXC-3031: Handle possible SST hang in garbd

### DIFF
--- a/garb/garb_gcs.cpp
+++ b/garb/garb_gcs.cpp
@@ -71,7 +71,7 @@ again:
     return ret;
 }
 
-void
+ssize_t
 Gcs::request_state_transfer (const std::string& request,
                              const std::string& donor)
 {
@@ -125,6 +125,8 @@ Gcs::request_state_transfer (const std::string& request,
                   << " (" << strerror(-ret) << ")";
         gu_throw_error(-ret) << "State transfer request failed";
     }
+
+    return ret;
 }
 
 void
@@ -166,6 +168,10 @@ Gcs::close ()
     {
         log_warn << "Attempt to close a closed connection";
     }
+}
+
+gcs_node_state_t Gcs::state_for(ssize_t idx) {
+  return gcs_get_state_for_idx(gcs_, idx);
 }
 
 } /* namespace garb */

--- a/garb/garb_gcs.hpp
+++ b/garb/garb_gcs.hpp
@@ -24,7 +24,7 @@ public:
 
     long recv (gcs_action& act);
 
-    void request_state_transfer (const std::string& request,
+    ssize_t request_state_transfer (const std::string& request,
                                  const std::string& donor);
 
     void join (const gu::GTID&, int code);
@@ -32,6 +32,8 @@ public:
     void set_last_applied(const gu::GTID&);
 
     int  proto_ver() const { return gcs_proto_ver(gcs_); }
+
+    gcs_node_state_t state_for(ssize_t idx);
 
     void close ();
 

--- a/garb/process.cc
+++ b/garb/process.cc
@@ -606,6 +606,16 @@ int process::wait() {
   return err_;
 }
 
+void process::interrupt() {
+  if (pid_) {
+    if (kill(pid_, SIGINT))
+    {
+      WSREP_WARN("Unable to interrupt process: %s: %d (%s)", str_, errno,
+                 strerror(errno));
+    }
+  }
+}
+
 void process::terminate() {
   WSREP_WARN("Terminating process");
   if (pid_) {

--- a/garb/process.h
+++ b/garb/process.h
@@ -85,6 +85,7 @@ class process {
   int wait();
   const char *cmd() { return str_; }
   void terminate();
+  void interrupt();
 };
 
 #endif /* PROCASS_H */

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -234,6 +234,12 @@ struct gcs_conn
     int outer_close_count; // how many times gcs_close has been called.
 };
 
+gcs_node_state_t gcs_get_state_for_idx(gcs_conn_t* conn, ssize_t idx) {
+  auto group = gcs_core_get_group(conn->core);
+  auto& node = group->nodes[idx];
+  return node.status;
+}
+
 // Oh C++, where art thou?
 struct gcs_recv_act
 {

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -515,6 +515,8 @@ extern void gcs_join_notification(gcs_conn_t *conn);
 
 extern void
 gcs_fetch_pfs_info (gcs_conn_t* conn, wsrep_node_info_t* entries, uint32_t size);
+
+gcs_node_state_t gcs_get_state_for_idx(gcs_conn_t* conn, ssize_t idx);
 #endif /* PXC */
 
 /*! A node with this name will be treated as a stateless arbitrator */

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1586,6 +1586,12 @@ void gcs_core_get_status(gcs_core_t* core, gu::Status& status)
     gu_mutex_unlock(&core->send_lock);
 }
 
+const gcs_group_t*
+gcs_core_get_group (const gcs_core_t* core)
+{
+    return &core->group;
+}
+
 #ifdef GCS_CORE_TESTING
 
 gcs_backend_t*
@@ -1610,12 +1616,6 @@ void
 gcs_core_set_state_uuid (gcs_core_t* core, const gu_uuid_t* uuid)
 {
     core->state_uuid = *uuid;
-}
-
-const gcs_group_t*
-gcs_core_get_group (const gcs_core_t* core)
-{
-    return &core->group;
 }
 
 gcs_fifo_lite_t*

--- a/gcs/src/gcs_core.hpp
+++ b/gcs/src/gcs_core.hpp
@@ -180,6 +180,10 @@ gcs_core_fetch_pfs_info(
     uint32_t size);
 #endif /* PXC */
 
+#include "gcs_group.hpp"
+extern const gcs_group_t*
+gcs_core_get_group (const gcs_core_t* core);
+
 #ifdef GCS_CORE_TESTING // things compiled only for unit tests
 
 /* gcs_core_send() interface does not allow enough concurrency control to model
@@ -203,10 +207,6 @@ gcs_core_send_step (gcs_core_t* core, long timeout_ms);
 
 extern void
 gcs_core_set_state_uuid (gcs_core_t* core, const gu_uuid_t* uuid);
-
-#include "gcs_group.hpp"
-extern const gcs_group_t*
-gcs_core_get_group (const gcs_core_t* core);
 
 #include "gcs_fifo_lite.hpp"
 extern gcs_fifo_lite_t*


### PR DESCRIPTION
Issue: when multiple (garbd) processes are started around the same time,
there is a good chance that both will request an SST transfer from the
same node at the same time.

The communication protocol doesn't handle this scenario well, and both
processes will think that they correctly selected a donor, and await
the data transfer. However, only one of them will receive it.

Fix: this commit improves the garbd process by sending a SIGINT signal
to the receiver script when the donor signals that the SST process
completed on its side (in practice, data is still in transmit at this
point).
The receiver script should trap this signal, and decide based on this if
it should continue waiting for data, or clean up and exit: if no data
was received until this signal, it should abort.