### PR TITLE
Fixed PXC-3353 and PXC-3404

### DIFF
--- a/garb/garb_main.cpp
+++ b/garb/garb_main.cpp
@@ -95,11 +95,11 @@ main (int argc, char* argv[])
     }
     catch (std::exception& e)
     {
-        log_fatal << "Exception in creating receive loop: " << e.what();
+        log_fatal << "Garbd exiting with error: " << e.what();
     }
     catch (...)
     {
-        log_fatal << "Exception in creating receive loop.";
+        log_fatal << "Garbd exiting";
     }
 
     return EXIT_FAILURE;

--- a/garb/garb_raii.h
+++ b/garb/garb_raii.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2020 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#ifndef GARB_RAII_INCLUDED
+#define GARB_RAII_INCLUDED 1
+#include "garb_gcs.hpp"
+
+/*
+  RAII class for freeing gcs action buffers.
+*/
+class Garb_gcs_action_buffer_guard {
+ public:
+  explicit Garb_gcs_action_buffer_guard(gcs_action *act) : m_act(act) {}
+
+  Garb_gcs_action_buffer_guard(const Garb_gcs_action_buffer_guard &) =
+      delete;  // copy constructor
+  Garb_gcs_action_buffer_guard operator=(Garb_gcs_action_buffer_guard &&) =
+      delete;  // move assignment
+  Garb_gcs_action_buffer_guard operator=(const Garb_gcs_action_buffer_guard &) =
+      delete;  // copy assignment
+
+  ~Garb_gcs_action_buffer_guard() {
+    if (m_act && m_act->buf) {
+      free(const_cast<void *>(m_act->buf));
+      m_act->buf = nullptr;
+    }
+  }
+
+ private:
+  gcs_action *m_act;
+};
+#endif /* GARB_RAII_INCLUDED */

--- a/garb/garb_recv_loop.cpp
+++ b/garb/garb_recv_loop.cpp
@@ -6,6 +6,7 @@
 #include <thread> 
 #include <atomic> 
 #include "process.h"
+#include "garb_raii.h" // Garb_gcs_action_buffer_guard
 
 namespace garb
 {
@@ -85,6 +86,7 @@ RecvLoop::loop()
         gcs_action act;
 
         gcs_.recv (act);
+        Garb_gcs_action_buffer_guard ag{&act};
 
         switch (act.type)
         {
@@ -211,11 +213,6 @@ RecvLoop::loop()
         case GCS_ACT_ERROR:
         case GCS_ACT_UNKNOWN:
             break;
-        }
-
-        if (act.buf)
-        {
-            ::free(const_cast<void*>(act.buf));
         }
     }
     return 0;

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1430,6 +1430,18 @@ _close(gcs_conn_t* conn, bool join_recv_thread)
         // FIXME: this can block waiting for applicaiton threads to fetch all
         // items. In certain situations this can block forever. Ticket #113
         gu_info ("Closing slave action queue.");
+
+#ifdef GCS_FOR_GARB
+        // We are at a state where both the gcomm thread and the receiver
+        // thread are no longer running. Empty the contents of the receiver
+        // queue before we destroy the gcs object in gcs_destroy().
+        if (GCS_CONN_CLOSED == conn->state) {
+            while (gu_fifo_length(conn->recv_q) != 0) {
+                gu_fifo_lock(conn->recv_q);
+                gu_fifo_pop_head(conn->recv_q);
+            }
+        }
+#endif /* GCS_FOR_GARB */
         gu_fifo_close (conn->recv_q);
     }
 


### PR DESCRIPTION
Part1
------
PXC-3353 Modify error handling in Garbd when donor crashes during SST or
             when an invalid donor name is passed to it

https://jira.percona.com/browse/PXC-3353

Problem:
When the donor node is killed while SST is in progress or when an
invalid donor is passed, the garbd hung forever waiting for the receiver
queue to get empty.

Analysis:
In both of the above cases, GCS (group_find_node_by_name()) considered
these errors as EHOSTUNREACH (No Route to Host), and triggers the
shutdown of garbd.

While the garbd main thread performs cleanup, the receiver thread would
still be queuing the received actions to the receiver queue until it
exits. So, this would result in the receiver queue to have a few
received actions which shall never be applied by the applier/main
thread.

When the main thread is performing the cleanup of the GCS
(gcs_destroy()), it sees the receiver queue to be not empty
(fifo_flush()) and thus ends up waiting on the conditional variable for
there will be no one to signal as all threads are already joined.

The garbd log will have

```
2020-09-16 09:18:19.664  INFO: recv_thread() joined.
2020-09-16 09:18:19.664  INFO: Closing replication queue.
2020-09-16 09:18:19.664  INFO: Closing slave action queue.
2020-09-16 09:18:19.664  WARN: Waiting for 2 items to be fetched.
... hangs ...
```
Stacktrace of the hang

```
(gdb) bt
futex_wait_cancelable
__pthread_cond_wait_common
__pthread_cond_wait
fifo_flush
gu_fifo_destroy
gcs_destroy
garb::Gcs::~Gcs
garb::RecvLoop::RecvLoop
garb::main
main
```

Fix:
Modified the error handling to empty the contents of the receiver queue
when garbd is exiting.

Part 2
-----
PXC-3404: Fixed memory leak in garbd while processing CC actions

https://jira.percona.com/browse/PXC-3404

When garbd is started with an invalid donor name, GCS didn't perform
proper cleanup of the gcs_action objects while handling the
STATE and COMPONENT messages, there by causing the memory leaks.

1. Leak during processing STATE messages.
    184 bytes in 1 blocks are definitely lost in loss record 1 of 2
    at 0x483B7F3: malloc
    by 0x12893B: gcs_act_cchange::write(void**) const (gcs_act_cchange.cpp:218)
    by 0x140E8E: gcs_group_act_conf(gcs_group*, gcs_act_rcvd*, int*) (gcs_group.cpp:2126)
    by 0x134AA0: core_handle_state_msg(gcs_core*, gcs_recv_msg*, gcs_act_rcvd*) (gcs_core.cpp:998)
    by 0x137051: gcs_core_recv(gcs_core*, gcs_act_rcvd*, long long) (gcs_core.cpp:1213)
    by 0x130DF5: gcs_recv_thread(void*) (gcs.cpp:1483)
    by 0x4875608: start_thread (pthread_create.c:477)
    by 0x50F6102: clone (clone.S:95)

2. Leak during processing COMPONENT messages.
    192 bytes in 2 blocks are definitely lost in loss record 2 of 2
    at 0x483B7F3: malloc
    by 0x12893B: gcs_act_cchange::write(void**) const (gcs_act_cchange.cpp:218)
    by 0x140E8E: gcs_group_act_conf(gcs_group*, gcs_act_rcvd*, int*) (gcs_group.cpp:2126)
    by 0x1344AD: core_handle_comp_msg(gcs_core*, gcs_recv_msg*, gcs_act_rcvd*) (gcs_core.cpp:863)
    by 0x136FFE: gcs_core_recv(gcs_core*, gcs_act_rcvd*, long long) (gcs_core.cpp:1203)
    by 0x130DF5: gcs_recv_thread(void*) (gcs.cpp:1483)
    by 0x4875608: start_thread (pthread_create.c:477)
    by 0x50F6102: clone (clone.S:95)

Fix:

For (1), A new RAII class `Garb_gcs_action_buffer_guard` has been introduced for
automatic freeing of gcs action objects in `RecvLoop::loop()` function.

For (2), the error handling in `_close()` function has been modified to
release the memory while emptying the contents of the receiver queue
when garbd is exiting.

Testing
-------
part1:
Jenkins: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/90/testReport/

Summary: The test `galera.galera_garbd_sst_failure` failed because of the missing `have_debug_sync.inc`. Other test failures are sporadic in nature.

part2:
Jenkins: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/98/testReport/

Summary: Test run in progress

Steps to reproduce
---
$ <path/to/>garbd --donor invalid --address "gcomm://127.0.0.1:4003" --group my_pxc --options 'base_port=12005;'