### PR TITLE
PXC-3416 Fix memory leaks in garbd when started with invalid group name

### DIFF
--- a/gcs/src/gcs_gcomm.cpp
+++ b/gcs/src/gcs_gcomm.cpp
@@ -230,6 +230,29 @@ public:
 
     ~GCommConn()
     {
+        // We cannot call gcs_close() to perform cleanup if there is an
+        // exception. So, we need to explicity free the objects in the
+        // destructor.
+        if (tp_ != nullptr)
+        {
+            delete tp_;
+        }
+
+        mutex_.lock();
+        if (!terminated_)
+        {
+            {
+                gcomm::Critical<Protonet> crit(*net_);
+                log_info << "gcomm: terminating thread";
+                terminated_ = true;
+                notify();
+            }
+            mutex_.unlock();
+            log_info << "gcomm: joining thread";
+            gu_thread_join(thd_, 0);
+            mutex_.lock();
+        }
+        mutex_.unlock();
         delete net_;
     }
 

--- a/gcs/src/gcs_gcomm.cpp
+++ b/gcs/src/gcs_gcomm.cpp
@@ -238,6 +238,7 @@ public:
             delete tp_;
         }
 
+        bool unlock_needed = true;
         mutex_.lock();
         if (!terminated_)
         {
@@ -248,11 +249,14 @@ public:
                 notify();
             }
             mutex_.unlock();
+            unlock_needed = false;
             log_info << "gcomm: joining thread";
             gu_thread_join(thd_, 0);
-            mutex_.lock();
         }
-        mutex_.unlock();
+        if (unlock_needed)
+        {
+            mutex_.unlock();
+        }
         delete net_;
     }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3416

When garbd is started with an invalid group name, GCS didn't perform
proper cleanup before shutting down the GCS objects there by causing the
memory leaks.

This patch fixes the majority of the memory leaks when garbd is started
with invalid group name.


Valgrind report leak before the fix:
```
2020-09-21 12:04:15.847 ERROR: failed to open gcomm backend connection: 110: failed to reach primary view (pc.wait_prim_timeout): 110 (Connection timed out)
	 at gcomm/src/pc.cpp:connect():159
2020-09-21 12:04:15.848 ERROR: gcs/src/gcs_core.cpp:gcs_core_open():220: Failed to open backend connection: -110 (Connection timed out)
2020-09-21 12:04:15.875 ERROR: gcs/src/gcs.cpp:gcs_open():1700: Failed to open channel 'amy_pxc' at 'gcomm://127.0.0.1:4003': -110 (Connection timed out)
2020-09-21 12:04:15.880 FATAL: Exception in creating receive loop: Failed to open connection to group: 110 (Connection timed out)
	 at garb/garb_gcs.cpp:Gcs():35
==64814== 
==64814== HEAP SUMMARY:
==64814==     in use at exit: 1,645,275 bytes in 99 blocks
==64814==   total heap usage: 10,199 allocs, 10,100 frees, 3,251,492 bytes allocated
==64814== 
==64814== 304 bytes in 1 blocks are possibly lost in loss record 41 of 63
==64814==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==64814==    by 0x40149CA: allocate_dtv (dl-tls.c:286)
==64814==    by 0x40149CA: _dl_allocate_tls (dl-tls.c:532)
==64814==    by 0x4876322: allocate_stack (allocatestack.c:622)
==64814==    by 0x4876322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==64814==    by 0x16B1B2: GCommConn::connect(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (gcs_gcomm.cpp:277)
==64814==    by 0x163F1D: gcomm_open(gcs_backend*, char const*, bool) (gcs_gcomm.cpp:859)
==64814==    by 0x14C836: gcs_core_open(gcs_core*, char const*, char const*, bool) (gcs_core.cpp:214)
==64814==    by 0x1413F5: gcs_open(gcs_conn*, char const*, char const*, bool) (gcs.cpp:1678)
==64814==    by 0x125E35: garb::Gcs::Gcs(gu::Config&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (garb_gcs.cpp:30)
==64814==    by 0x130D00: garb::RecvLoop::RecvLoop(garb::Config const&) (garb_recv_loop.cpp:34)
==64814==    by 0x11FFEA: garb::main(int, char**) (garb_main.cpp:93)
==64814==    by 0x120273: main (garb_main.cpp:115)
==64814== 
==64814== 45,349 (832 direct, 44,517 indirect) bytes in 1 blocks are definitely lost in loss record 57 of 63
==64814==    at 0x483BE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==64814==    by 0x17D51C: gcomm::Transport::create(gcomm::Protonet&, gu::URI const&) (transport.cpp:72)
==64814==    by 0x16B2EA: GCommConn::connect(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (gcs_gcomm.cpp:303)
==64814==    by 0x163F1D: gcomm_open(gcs_backend*, char const*, bool) (gcs_gcomm.cpp:859)
==64814==    by 0x14C836: gcs_core_open(gcs_core*, char const*, char const*, bool) (gcs_core.cpp:214)
==64814==    by 0x1413F5: gcs_open(gcs_conn*, char const*, char const*, bool) (gcs.cpp:1678)
==64814==    by 0x125E35: garb::Gcs::Gcs(gu::Config&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (garb_gcs.cpp:30)
==64814==    by 0x130D00: garb::RecvLoop::RecvLoop(garb::Config const&) (garb_recv_loop.cpp:34)
==64814==    by 0x11FFEA: garb::main(int, char**) (garb_main.cpp:93)
==64814==    by 0x120273: main (garb_main.cpp:115)
==64814== 
==64814== 1,599,622 (640 direct, 1,598,982 indirect) bytes in 1 blocks are definitely lost in loss record 63 of 63
==64814==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==64814==    by 0x13E073: gcs_create(gu_config*, gcache_t*, char const*, char const*, int, int) (gcs.cpp:310)
==64814==    by 0x125E1A: garb::Gcs::Gcs(gu::Config&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (garb_gcs.cpp:19)
==64814==    by 0x130D00: garb::RecvLoop::RecvLoop(garb::Config const&) (garb_recv_loop.cpp:34)
==64814==    by 0x11FFEA: garb::main(int, char**) (garb_main.cpp:93)
==64814==    by 0x120273: main (garb_main.cpp:115)
==64814== 
==64814== LEAK SUMMARY:
==64814==    definitely lost: 1,472 bytes in 2 blocks
==64814==    indirectly lost: 1,643,499 bytes in 96 blocks
==64814==      possibly lost: 304 bytes in 1 blocks
==64814==    still reachable: 0 bytes in 0 blocks
==64814==         suppressed: 0 bytes in 0 blocks
==64814== 
==64814== For lists of detected and suppressed errors, rerun with: -s
==64814== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```
Valgrind report leak after the fix:
```
2020-09-23 19:38:26.765 ERROR: failed to open gcomm backend connection: 110: failed to reach primary view (pc.wait_prim_timeout): 110 (Connection timed out)
	 at gcomm/src/pc.cpp:connect():159
2020-09-23 19:38:26.766 ERROR: gcs/src/gcs_core.cpp:gcs_core_open():220: Failed to open backend connection: -110 (Connection timed out)
2020-09-23 19:38:27.790  INFO: gcomm: joining thread
2020-09-23 19:38:27.810 ERROR: gcs/src/gcs.cpp:gcs_open():1700: Failed to open channel 'my_pxc1' at 'gcomm://127.0.0.1:4003': -110 (Connection timed out)
2020-09-23 19:38:27.818 FATAL: Exception in creating receive loop: Failed to open connection to group: 110 (Connection timed out)
	 at garb/garb_gcs.cpp:Gcs():35
==159096== 
==159096== HEAP SUMMARY:
==159096==     in use at exit: 0 bytes in 0 blocks
==159096==   total heap usage: 10,211 allocs, 10,211 frees, 3,253,419 bytes allocated
==159096== 
==159096== All heap blocks were freed -- no leaks are possible
==159096== 
==159096== For lists of detected and suppressed errors, rerun with: -s
==159096== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
Steps to Reproduce:
```
$ valgrind --leak-check=full $PWD/garb/garbd --donor <valid> --address "gcomm://127.0.0.1:4003" --group <invalid_group_name> --options 'base_port=12005;
```

Testing
-----
Jenkins: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/97/testReport/
Summary: Failing tests sporadic in nature and are unrelated to the current fix. Reported [PXC-3431](https://jira.percona.com/browse/PXC-3431) for the failing tests.