### PR TITLE
PXC-3424: Fix error handling when donor is not able

### DIFF
--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1072,11 +1072,18 @@ core_msg_to_action (gcs_core_t*          core,
             assert (gcs_group_my_idx(group) == msg->sender_idx || 0 >= ret);
             if (-ENOTRECOVERABLE == ret) {
                 core->backend.close(&core->backend);
+#ifdef GCS_FOR_GARB
                 // A negative return value ends the receive loop, as this is
                 // an unrecoverable error.
-                // There was originally an abort here, which prevents
-                // proper cleanup
                 ret = -1;
+#else
+                // See #165.
+                // There is nobody to pass this error to for graceful shutdown:
+                // application thread is blocked waiting for SST.
+                // Also note that original ret value is not preserved on return
+                // so this must be done here.
+                gu_abort();
+#endif
                 break;
             }
             else if (ret != 0)


### PR DESCRIPTION
to serve SST

Reverted to the original behavior which was changed for garbd.
The changed behavior prevented propagation of abort signal up to the
galera library client (app_callback) where we stop sst script.