### PR TITLE
[3.x-5.7] PXC-3418: Cluster node locked up with alter table and concurrent RW load

### DIFF
--- a/galera/src/monitor.hpp
+++ b/galera/src/monitor.hpp
@@ -8,6 +8,7 @@
 #include "trx_handle.hpp"
 #include <gu_lock.hpp> // for gu::Mutex and gu::Cond
 #include <gu_limits.h>
+#include <gu_dbug.h>
 
 #include <vector>
 
@@ -175,7 +176,8 @@ namespace galera
 
             assert(obj_seqno > last_left_);
 
-            while (obj_seqno - last_left_ >= process_size_)
+            while (obj_seqno - last_left_ >= process_size_
+                  || GU_DBUG_EVALUATE_IF ("simulate_low_process_size", 1, 0))
                 // TODO: exit on error
             {
                 log_warn << "Trying to self-cancel seqno out of process "

--- a/galerautils/src/gu_dbug.h
+++ b/galerautils/src/gu_dbug.h
@@ -141,6 +141,10 @@ extern "C"
 
 #define GU_DBUG_EXECUTE(keyword,a1) \
         {if (_gu_db_on_) {if (_gu_db_keyword_ (keyword)) { a1 }}}
+#define GU_DBUG_EVALUATE(keyword,a1,a2) \
+        ((_gu_db_on_)? (_gu_db_keyword_ (keyword)? (a1) : (a2)) : false )
+#define GU_DBUG_EVALUATE_IF(keyword,a1,a2) \
+        ((_gu_db_on_)? (_gu_db_keyword_ (keyword)? (a1) : (a2)) : false )
 
 #define GU_DBUG_PRINT(keyword,arglist) \
         {if (_gu_db_on_) {_gu_db_pargs_(__LINE__,keyword); \


### PR DESCRIPTION
Introduced GU_DBUG_EVALUATE for MTR testing.