### PR TITLE
[4.x-8.0] PXC-3418: Cluster node locked up with alter table and concurrent RW load

### DIFF
--- a/galerautils/src/gu_dbug.h
+++ b/galerautils/src/gu_dbug.h
@@ -141,6 +141,10 @@ extern "C"
 
 #define GU_DBUG_EXECUTE(keyword,a1) \
         {if (_gu_db_on_) {if (_gu_db_keyword_ (keyword)) { a1 }}}
+#define GU_DBUG_EVALUATE(keyword,a1,a2) \
+        ((_gu_db_on_)? (_gu_db_keyword_ (keyword)? (a1) : (a2)) : false )
+#define GU_DBUG_EVALUATE_IF(keyword,a1,a2) \
+        ((_gu_db_on_)? (_gu_db_keyword_ (keyword)? (a1) : (a2)) : false )
 
 #define GU_DBUG_PRINT(keyword,arglist) \
         {if (_gu_db_on_) {_gu_db_pargs_(__LINE__,keyword); \


### PR DESCRIPTION
Introduced GU_DBUG_EVALUATE for MTR testing.

Note to Reviewers
-----
1. The code changes from https://github.com/percona/galera/pull/197/files#diff-8f949a3279b73d7724b5b8562714b290069cad3f2c85142424474f2149c76fd2 were not ported to 4.x-8.0 as that code is never hit on 8.0.

2. This commit adds `GU_DBUG_EVALUATE` for MTR testing. But it is not being used in the tests added as part of the https://github.com/percona/percona-xtradb-cluster/pull/1303