### PR TITLE
PXC-3538: Garbd crashes after successful backup

### DIFF
--- a/garb/garb_gcs.cpp
+++ b/garb/garb_gcs.cpp
@@ -149,11 +149,11 @@ Gcs::set_last_applied (const gu::GTID& gtid)
 }
 
 void
-Gcs::close ()
+Gcs::close (bool explicit_close)
 {
     if (!closed_)
     {
-        ssize_t ret = gcs_close (gcs_);
+        ssize_t ret = gcs_close (gcs_, explicit_close);
 
         if (ret < 0)
         {

--- a/garb/garb_gcs.hpp
+++ b/garb/garb_gcs.hpp
@@ -35,7 +35,7 @@ public:
 
     gcs_node_state_t state_for(ssize_t idx);
 
-    void close ();
+    void close (bool explicit_close = false);
 
 private:
 

--- a/garb/garb_recv_loop.cpp
+++ b/garb/garb_recv_loop.cpp
@@ -130,7 +130,7 @@ RecvLoop::loop()
                             pipe_to_log(p.err_pipe());
                             log_info << "SST script ended";
                             sst_ended = true;
-                            gcs_.close();
+                            gcs_.close(true);
                         });
 
                         sst_out_log = std::thread([&](){
@@ -199,7 +199,7 @@ RecvLoop::loop()
             {
                 // we requested custom SST, so we're done here
                 if(config_.recv_script().empty()) {
-                    gcs_.close();
+                    gcs_.close(true);
                 }
             }
 
@@ -207,7 +207,7 @@ RecvLoop::loop()
         }
         case GCS_ACT_INCONSISTENCY:
             // something went terribly wrong, restart needed
-            gcs_.close();
+            gcs_.close(true);
             return 2;
         case GCS_ACT_JOIN:
         case GCS_ACT_SYNC:

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1395,7 +1395,11 @@ _check_recv_queue_growth (gcs_conn_t* conn, ssize_t size)
 }
 
 static long
+#ifdef GCS_FOR_GARB
+_close(gcs_conn_t* conn, bool join_recv_thread, bool explicit_close = false)
+#else
 _close(gcs_conn_t* conn, bool join_recv_thread)
+#endif
 {
     /* all possible races in connection closing should be resolved by
      * the following call, it is thread-safe */
@@ -1459,7 +1463,7 @@ _close(gcs_conn_t* conn, bool join_recv_thread)
         // thread are no longer running. Empty the contents of the receiver
         // queue and release the buffer before we destroy the gcs object in
         // gcs_destroy().
-        if (GCS_CONN_CLOSED == conn->state) {
+        if (GCS_CONN_CLOSED == conn->state && !explicit_close) {
             int err = 0;
             struct gcs_recv_act* recv_act = nullptr;
 
@@ -1770,7 +1774,11 @@ out:
 /* After it returns, application should have all time in the world to cancel
  * and join threads which try to access the handle, before calling gcs_destroy()
  * on it. */
+#ifdef GCS_FOR_GARB
+long gcs_close (gcs_conn_t *conn, bool explicit_close)
+#else
 long gcs_close (gcs_conn_t *conn)
+#endif
 {
     long ret;
 
@@ -1778,7 +1786,11 @@ long gcs_close (gcs_conn_t *conn)
         return -EALREADY;
     }
 
+#ifdef GCS_FOR_GARB
+    if ((ret = _close(conn, true, explicit_close)) == -EALREADY)
+#else
     if ((ret = _close(conn, true)) == -EALREADY)
+#endif
     {
         gu_info("recv_thread() already closing, joining thread.");
         /* _close() has already been called by gcs_recv_thread() and it

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -111,7 +111,11 @@ extern long gcs_open  (gcs_conn_t *conn,
  * @param  conn connection handle
  * @return negative error code or 0 in case of success.
  */
+#ifdef GCS_FOR_GARB
+extern long gcs_close (gcs_conn_t *conn, bool explicit_close = false);
+#else
 extern long gcs_close (gcs_conn_t *conn);
+#endif
 
 /*! @brief Frees resources associuated with connection handle.
  *


### PR DESCRIPTION
Issue: a garb specific code in GCS clears the receiving queue when
the connection is closed. This patch was added to fix the case where
an exception stopped the main loop, and the GCS thread never exited
because there were still items in the queue.

While this patch fixed the original (exception) issue, it also caused
a new one: on normal exit, there is now a race between the receiver
loop and the queue clearer code in the close method. If the close method
wins, the receiver loop will wait on a closed empty queue and will fail.

Fix: only execute the clearing code in the close method if the close
method was implicitly. This only happens when an exception occurs in the
receiver loop, and the Gcs object goes out of scope.

On normal shutdown, the close method is called explicitly, and cleanup
happens as before: the receiver loop waits for the last self-leave
event, and ends after that.