### PR TITLE
PXC-3437: State transfer fails when IST donor select incorrect seqno

### DIFF
--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -474,10 +474,11 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
         if (istr.uuid() == state_uuid_ && istr.last_applied() >= 0) {
           log_info << "IST request: " << istr;
 
+          wsrep_seqno_t const min_available = std::max(cc_lowest_trx_seqno_, gcache_.seqno_min());
           wsrep_seqno_t const first(
               (str_proto_ver < 3 || cc_lowest_trx_seqno_ == 0)
                   ? istr.last_applied() + 1
-                  : std::min(cc_lowest_trx_seqno_, istr.last_applied() + 1));
+                  : std::min(min_available, istr.last_applied() + 1));
 
           try {
 #ifdef PXC


### PR DESCRIPTION
Issue: when a joiner requests a state transfer, the donor first checks
if it can serve the transfer using for IST. For this check it prefers the
lowest cluster seqno, which was calculated during the last CC event,
instead of the actual seqno requested by the joiner (if it is smaller).

However it is possible that this seqno was released since then, and it
is no longer present in the galera cache, which causes the state
transfer to fail, with the "Cert index preload first seqno XXX not
found..." error message.

Fix: this commit modifies the min available seqno check so that it also
takes the current local starting GCache entry into calculation.

Since a successful state transfer will result in a configuration change
the actual cc_lowest_seqno value will be corrected after the transfer
completes.