### PR TITLE
PXC-3580: Aggressive network outages on one node makes the whole cluster unusable

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -596,7 +596,7 @@ galera::NBOEntry copy_ts(
                                << " out of range";
     gcs_action act = {ts->global_seqno(), ts->local_seqno(),
                       buf->data(), static_cast<int32_t>(buf->size()),
-                      GCS_ACT_WRITESET};
+                      GCS_ACT_WRITESET, 0};
     if (ts->certified() == false)
     {
         // TrxHandleSlave is from group

--- a/galera/src/gcs_action_source.cpp
+++ b/galera/src/gcs_action_source.cpp
@@ -126,7 +126,7 @@ void galera::GcsActionSource::dispatch(void* const              recv_ctx,
         break;
     case GCS_ACT_STATE_REQ:
         gu_trace(replicator_.process_state_req(recv_ctx, act.buf, act.size,
-                                               act.seqno_l, act.seqno_g));
+                                               act.seqno_l, act.seqno_g, act.sender_id));
         break;
     case GCS_ACT_JOIN:
     {

--- a/galera/src/ist.cpp
+++ b/galera/src/ist.cpp
@@ -14,6 +14,10 @@
 #include <boost/bind.hpp>
 #include <fstream>
 #include <algorithm>
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
 
 namespace
 {
@@ -35,11 +39,13 @@ namespace galera
                         wsrep_seqno_t last,
                         wsrep_seqno_t preload_start,
                         AsyncSenderMap& asmap,
-                        int version)
+                        int version,
+                        const std::string& sender_id)
                 :
                 Sender (conf, asmap.gcache(), peer, version),
                 conf_  (conf),
                 peer_  (peer),
+                peer_id_ (sender_id),
                 first_ (first),
                 last_  (last),
                 preload_start_(preload_start),
@@ -49,6 +55,7 @@ namespace galera
 
             const gu::Config&  conf()   { return conf_;   }
             const std::string& peer()  const { return peer_;   }
+            const std::string& peer_id() const { return peer_id_;  }
             wsrep_seqno_t      first() const { return first_;  }
             wsrep_seqno_t      last()  const { return last_;   }
             wsrep_seqno_t      preload_start() const { return preload_start_; }
@@ -61,6 +68,7 @@ namespace galera
 
             const gu::Config&   conf_;
             std::string const   peer_;
+            std::string const   peer_id_;
             wsrep_seqno_t const first_;
             wsrep_seqno_t const last_;
             wsrep_seqno_t const preload_start_;
@@ -395,6 +403,88 @@ galera::ist::Receiver::prepare(wsrep_seqno_t const first_seqno,
 }
 
 
+class SocketWatchdog
+{
+    public:
+        explicit SocketWatchdog(std::function<void()> onExpire, unsigned int timeoutMs = 10000)
+            : eventCbFn_(onExpire)
+            , active_(false)
+            , alive_(true)
+            , expire_cnt_(timeoutMs/10)
+            , mtx_()
+            , cv_()
+            , t_([this]() {
+
+              bool aliveSnapshot = alive_;
+
+              while(aliveSnapshot) {
+                bool activeSnapshot = false;
+                aliveSnapshot = false;
+                int counter = 0;
+
+                {
+                  std::unique_lock<std::mutex> lock(mtx_);
+                  while(!active_) cv_.wait(lock);
+                  activeSnapshot = active_;
+                  aliveSnapshot = alive_;
+                  counter = expire_cnt_;
+                }
+
+                while (activeSnapshot && aliveSnapshot) {
+                    if (counter == 0) {
+
+                        eventCbFn_();
+
+                        std::unique_lock<std::mutex> lock(mtx_);
+                        active_ = false;
+                        break;
+                    }
+
+                    {
+                        std::unique_lock<std::mutex> lock(mtx_);
+                        cv_.wait_for(lock, std::chrono::milliseconds(10));
+                        activeSnapshot = active_;
+                        aliveSnapshot = alive_;
+                    }
+                    --counter;
+                }
+              }
+          }) { }
+
+        ~SocketWatchdog() {
+            {
+                std::unique_lock<std::mutex> lock(mtx_);
+                alive_ = false;
+                active_ = true;
+                cv_.notify_one();
+            }
+            t_.join();
+
+        }
+
+        void restart() {
+            std::unique_lock<std::mutex> lock(mtx_);
+            active_ = true;
+            cv_.notify_one();
+        }
+
+        void stop() {
+            std::unique_lock<std::mutex> lock(mtx_);
+            active_ = false;
+            cv_.notify_one();
+        }
+
+    private:
+        std::function<void()> eventCbFn_;
+        bool active_;
+        bool alive_;
+        int expire_cnt_;
+        std::mutex mtx_;
+        std::condition_variable cv_;
+
+        std::thread t_;
+};
+
 void galera::ist::Receiver::run()
 {
     asio::ip::tcp::socket socket(io_service_);
@@ -472,223 +562,236 @@ void galera::ist::Receiver::run()
         bool preload_started(false);
         current_seqno_ = WSREP_SEQNO_UNDEFINED;
 
-        while (true)
         {
-            std::pair<gcs_action, bool> ret;
-
-            if (use_ssl_ == true)
-            {
-                p.recv_ordered(ssl_stream, ret);
-            }
-            else
-            {
-                p.recv_ordered(socket, ret);
-            }
-
-            gcs_action& act(ret.first);
-
-            // act type GCS_ACT_UNKNOWN denotes EOF
-            if (gu_unlikely(act.type == GCS_ACT_UNKNOWN))
-            {
-                assert(0    == act.seqno_g);
-                assert(NULL == act.buf);
-                assert(0    == act.size);
-                log_debug << "eof received, closing socket";
-                break;
-            }
-
-            assert(act.seqno_g > 0);
-
-            if (gu_unlikely(WSREP_SEQNO_UNDEFINED == current_seqno_))
-            {
-                assert(!progress);
-                if (act.seqno_g > first_seqno_)
-                {
-                    log_error
-                        << "IST started with wrong seqno: " << act.seqno_g
-                        << ", expected <= " << first_seqno_;
-                    ec = EINVAL;
-                    goto err;
+            SocketWatchdog watchdog([&ssl_stream, &socket, this]() {
+                fprintf(stderr, "SocketWatchdog expired. use_ssl_: %d\n", use_ssl_);
+                if (use_ssl_) {
+                    ssl_stream.lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both);
+                } else {
+                    socket.shutdown(asio::socket_base::shutdown_type::shutdown_both);
                 }
-                log_info << "####### IST current seqno initialized to "
-                         << act.seqno_g;
-                current_seqno_ = act.seqno_g;
-                progress = new gu::Progress<wsrep_seqno_t>(
-                    "Receiving IST", " events",
-                    last_seqno_ - current_seqno_ + 1,
-                    /* The following means reporting progress NO MORE frequently
-                     * than once per BOTH 10 seconds (default) and 16 events */
-                    16);
-            }
-            else
+            });
+
+            while (true)
             {
-                assert(progress);
-
-                ++current_seqno_;
-
-                progress->update(1);
-            }
-
-            if (act.seqno_g != current_seqno_)
-            {
-                log_error << "Unexpected action seqno: " << act.seqno_g
-                          << " expected: " << current_seqno_;
-                ec = EINVAL;
-                goto err;
-            }
-
-            assert(current_seqno_ > 0);
-            assert(current_seqno_ == act.seqno_g);
-            assert(act.type != GCS_ACT_UNKNOWN);
-
-            /* Say use-case is booting 3 node cluster n1, n2, n3 all from scratch.
-            - n1 bootstraps and create cluster with state x:1
-            - n2 boots up and joins cluster moving cluster state from x:1 -> x:2
-            - n2 then demands SST since state of n2 is 0:-1.
-            - n1 decided to donate SST to n2.
-            - As per new G-4 protocol cc events are all persisted.
-              n2 raises SST followed by IST request.
-            - n2 demands IST request for 0-2.
-            - n1 detects SST action and decided to process IST only for 2-2
-            - n2 gets SST state that represent x:2 followed by IST with
-              write-set = 2.
-            - Since n2 already has write-set = 2 it ignores applying
-              the said write-set.
-            (n3 will join post this with same sequencing).
-
-            .... this is how normal flow happens.
-
-            so process of joinint the node can be summarized as
-            (a) grant membership and update configuration (that is persisted).
-            (b) request SST + IST (with range).
-            (c) donor kicks-off IST (async action).
-            (d) donor initiate SST (again async action).
-            (e) joiner before applying IST wait for SST to complete.
-            (f) post SST joiner apply IST only write set > sst-write-set.
-            (e) other write-set still are cached in gcache and are added
-                to gcache maintain seqno2ptr.
-
-            use-case-1
-            ----------
-
-            Now say n3 joins after n2 is done with (c) but before donor
-            initiate (d). n1 updates membership and update cc moving state
-            from x:2 -> x:3. Post SST n2 get state = x:3 (first_seqno_ = 3).
-            Check below (must_apply) will ignore applying write-set from
-            IST channel as  2 < 3 that suggest SST already got changes from
-            write-set 2 so no need to apply it but write-set is kept active
-            in gcache so cert preload is reset back to (2) from (3) that was
-            set immediately post-SST.
-
-            Write-set (CC event) registered with seqno=3 is also delivered to
-            n2 through group channel. n2 ignore processing group channel
-            delivered event given the said event (creation of updated view)
-            as it is already present through SST.
-
-            While n2 ignores applying this event it is also freed from gcache.
-            This creates inconsistency as n2 maintained gcache now has
-            event=2, event=3 (absent), other events.....
-            gcache is expected to have all events sequentially.
-            [recv_ordered that read events from ist channel caches the events
-             to gcache and also add it to the gcache vector seqno2ptr]
-
-            fix-1: ensure such ignored event are added gcache.
-
-            use-case-2
-            ----------
-
-            Now say n3 joins between (b) and (c). n1 updates membership from
-            x:2 -> x:3 and initiate IST. IST followed by SST is never processed
-            based on demand but based on donor state so donor initiate IST
-            with write-set 3-3.
-
-            n2 demanded 0-2 but received IST write-set=3 and SST with write-sets
-            upto = 3. n2 also recieved the said write-set from group channel since
-            n2 was part of the group channel when n3 joined.
-            n2 ignores processing of the event received from group channel
-            (ignore creation of view since the view is already created through
-             SST restoration) but try to add the said ignored event to gcache
-            as per the protocol established above. Unfortunately, it hits an
-            error here because IST during its processing has already added it.
-
-            fix-2: avoid adding events to gcache that has
-                   seqno > ist-demanded-seqno (3 > 2 avoid adding 3).
-
-            use-case-3:
-            -----------
-
-            Now say instead of n3 joining n2 which is already part of the cluster
-            and waiting for SST + IST faces some n/w glitch.
-
-            This cause another configuration change registered under seqno=3
-            but this cc is not delivered to n2 due to n/w issue.
-
-            Once n/w is back n2 get the SST with state = x:3 and IST with seqno=2.
-            As as explained in use-case-1 it ignored seqno=2 (2 < 3) but
-            as it was case in use-case-1 local ordered CC event cause addition
-            of seqno=3 to gcache vector but since this event never got delivered
-            this seqno is not added to gcache. Instead it processes an event
-            with CC = -1 that registers its disconnection from the cluster.
-            Eventually it catches up with the cluster through IST demanding
-            3-4 writeset as n2 has registered state = 3 from SST but this causes
-            inconsistency in gcache seqno2ptr vector as write-set 3 never get
-            registered.
-            */
-
-            bool const must_apply(current_seqno_ >= first_seqno_);
-            bool const preload(ret.second);
-
-            if (gu_unlikely(preload == true && preload_started == false))
-            {
-                log_info << "IST preload starting at " << current_seqno_;
-                preload_started = true;
-            }
-
-            switch (act.type)
-            {
-            case GCS_ACT_WRITESET:
-            {
-                TrxHandleSlavePtr ts(
-                    TrxHandleSlavePtr(TrxHandleSlave::New(false,
-                                                          slave_pool_),
-                                      TrxHandleSlaveDeleter()));
-                if (act.size > 0)
+                std::pair<gcs_action, bool> ret;
+                watchdog.restart();
+                if (use_ssl_ == true)
                 {
-                    gu_trace(ts->unserialize<false>(act));
-                    ts->set_local(false);
-                    assert(ts->global_seqno() == act.seqno_g);
-                    assert(ts->depends_seqno() >= 0 || ts->nbo_end());
-                    assert(ts->action().first && ts->action().second);
-                    // Checksum is verified later on
+                    p.recv_ordered(ssl_stream, ret);
                 }
                 else
                 {
-                    ts->set_global_seqno(act.seqno_g);
-                    ts->mark_dummy_with_action(act.buf);
+                    p.recv_ordered(socket, ret);
+                }
+                watchdog.stop();
+
+                gcs_action& act(ret.first);
+
+                // act type GCS_ACT_UNKNOWN denotes EOF
+                if (gu_unlikely(act.type == GCS_ACT_UNKNOWN))
+                {
+                    assert(0    == act.seqno_g);
+                    assert(NULL == act.buf);
+                    assert(0    == act.size);
+                    log_debug << "eof received, closing socket";
+                    break;
                 }
 
-                log_info << "####### Passing WS " << act.seqno_g;
-                handler_.ist_trx(ts, must_apply, preload);
-                break;
-            }
-            case GCS_ACT_CCHANGE:
-                log_info << "####### Passing IST CC " << act.seqno_g
-                         << ", must_apply: " << must_apply
-                         << ", preload: " << (preload ? "true" : "false");
-                handler_.ist_cc(act, must_apply, preload);
-                break;
-            default:
-                assert(0);
+                assert(act.seqno_g > 0);
+
+                if (gu_unlikely(WSREP_SEQNO_UNDEFINED == current_seqno_))
+                {
+                    assert(!progress);
+                    if (act.seqno_g > first_seqno_)
+                    {
+                        log_error
+                            << "IST started with wrong seqno: " << act.seqno_g
+                            << ", expected <= " << first_seqno_;
+                        ec = EINVAL;
+                        goto err;
+                    }
+                    log_info << "####### IST current seqno initialized to "
+                            << act.seqno_g;
+                    current_seqno_ = act.seqno_g;
+                    progress = new gu::Progress<wsrep_seqno_t>(
+                        "Receiving IST", " events",
+                        last_seqno_ - current_seqno_ + 1,
+                        /* The following means reporting progress NO MORE frequently
+                        * than once per BOTH 10 seconds (default) and 16 events */
+                        1, "PT1S");
+                }
+                else
+                {
+                    assert(progress);
+
+                    ++current_seqno_;
+                    progress->update(1);
+                }
+
+                if (act.seqno_g != current_seqno_)
+                {
+                    log_error << "Unexpected action seqno: " << act.seqno_g
+                            << " expected: " << current_seqno_;
+                    ec = EINVAL;
+                    goto err;
+                }
+
+                assert(current_seqno_ > 0);
+                assert(current_seqno_ == act.seqno_g);
+                assert(act.type != GCS_ACT_UNKNOWN);
+
+                /* Say use-case is booting 3 node cluster n1, n2, n3 all from scratch.
+                - n1 bootstraps and create cluster with state x:1
+                - n2 boots up and joins cluster moving cluster state from x:1 -> x:2
+                - n2 then demands SST since state of n2 is 0:-1.
+                - n1 decided to donate SST to n2.
+                - As per new G-4 protocol cc events are all persisted.
+                n2 raises SST followed by IST request.
+                - n2 demands IST request for 0-2.
+                - n1 detects SST action and decided to process IST only for 2-2
+                - n2 gets SST state that represent x:2 followed by IST with
+                write-set = 2.
+                - Since n2 already has write-set = 2 it ignores applying
+                the said write-set.
+                (n3 will join post this with same sequencing).
+
+                .... this is how normal flow happens.
+
+                so process of joinint the node can be summarized as
+                (a) grant membership and update configuration (that is persisted).
+                (b) request SST + IST (with range).
+                (c) donor kicks-off IST (async action).
+                (d) donor initiate SST (again async action).
+                (e) joiner before applying IST wait for SST to complete.
+                (f) post SST joiner apply IST only write set > sst-write-set.
+                (e) other write-set still are cached in gcache and are added
+                    to gcache maintain seqno2ptr.
+
+                use-case-1
+                ----------
+
+                Now say n3 joins after n2 is done with (c) but before donor
+                initiate (d). n1 updates membership and update cc moving state
+                from x:2 -> x:3. Post SST n2 get state = x:3 (first_seqno_ = 3).
+                Check below (must_apply) will ignore applying write-set from
+                IST channel as  2 < 3 that suggest SST already got changes from
+                write-set 2 so no need to apply it but write-set is kept active
+                in gcache so cert preload is reset back to (2) from (3) that was
+                set immediately post-SST.
+
+                Write-set (CC event) registered with seqno=3 is also delivered to
+                n2 through group channel. n2 ignore processing group channel
+                delivered event given the said event (creation of updated view)
+                as it is already present through SST.
+
+                While n2 ignores applying this event it is also freed from gcache.
+                This creates inconsistency as n2 maintained gcache now has
+                event=2, event=3 (absent), other events.....
+                gcache is expected to have all events sequentially.
+                [recv_ordered that read events from ist channel caches the events
+                to gcache and also add it to the gcache vector seqno2ptr]
+
+                fix-1: ensure such ignored event are added gcache.
+
+                use-case-2
+                ----------
+
+                Now say n3 joins between (b) and (c). n1 updates membership from
+                x:2 -> x:3 and initiate IST. IST followed by SST is never processed
+                based on demand but based on donor state so donor initiate IST
+                with write-set 3-3.
+
+                n2 demanded 0-2 but received IST write-set=3 and SST with write-sets
+                upto = 3. n2 also recieved the said write-set from group channel since
+                n2 was part of the group channel when n3 joined.
+                n2 ignores processing of the event received from group channel
+                (ignore creation of view since the view is already created through
+                SST restoration) but try to add the said ignored event to gcache
+                as per the protocol established above. Unfortunately, it hits an
+                error here because IST during its processing has already added it.
+
+                fix-2: avoid adding events to gcache that has
+                    seqno > ist-demanded-seqno (3 > 2 avoid adding 3).
+
+                use-case-3:
+                -----------
+
+                Now say instead of n3 joining n2 which is already part of the cluster
+                and waiting for SST + IST faces some n/w glitch.
+
+                This cause another configuration change registered under seqno=3
+                but this cc is not delivered to n2 due to n/w issue.
+
+                Once n/w is back n2 get the SST with state = x:3 and IST with seqno=2.
+                As as explained in use-case-1 it ignored seqno=2 (2 < 3) but
+                as it was case in use-case-1 local ordered CC event cause addition
+                of seqno=3 to gcache vector but since this event never got delivered
+                this seqno is not added to gcache. Instead it processes an event
+                with CC = -1 that registers its disconnection from the cluster.
+                Eventually it catches up with the cluster through IST demanding
+                3-4 writeset as n2 has registered state = 3 from SST but this causes
+                inconsistency in gcache seqno2ptr vector as write-set 3 never get
+                registered.
+                */
+
+                bool const must_apply(current_seqno_ >= first_seqno_);
+                bool const preload(ret.second);
+
+                if (gu_unlikely(preload == true && preload_started == false))
+                {
+                    log_info << "IST preload starting at " << current_seqno_;
+                    preload_started = true;
+                }
+
+                switch (act.type)
+                {
+                case GCS_ACT_WRITESET:
+                {
+                    TrxHandleSlavePtr ts(
+                        TrxHandleSlavePtr(TrxHandleSlave::New(false,
+                                                            slave_pool_),
+                                        TrxHandleSlaveDeleter()));
+                    if (act.size > 0)
+                    {
+                        gu_trace(ts->unserialize<false>(act));
+                        ts->set_local(false);
+                        assert(ts->global_seqno() == act.seqno_g);
+                        assert(ts->depends_seqno() >= 0 || ts->nbo_end());
+                        assert(ts->action().first && ts->action().second);
+                        // Checksum is verified later on
+                    }
+                    else
+                    {
+                        ts->set_global_seqno(act.seqno_g);
+                        ts->mark_dummy_with_action(act.buf);
+                    }
+
+                    log_info << "####### Passing WS " << act.seqno_g;
+                    handler_.ist_trx(ts, must_apply, preload);
+                    break;
+                }
+                case GCS_ACT_CCHANGE:
+                    log_info << "####### Passing IST CC " << act.seqno_g
+                            << ", must_apply: " << must_apply
+                            << ", preload: " << (preload ? "true" : "false");
+                    handler_.ist_cc(act, must_apply, preload);
+                    break;
+                default:
+                    assert(0);
+                }
             }
         }
-
         if (progress /* IST actually started */) progress->finish();
     }
     catch (asio::system_error& e)
     {
-        log_error << "got asio system error while reading IST stream: "
-                  << e.code();
         ec = e.code().value();
+        if (ec == asio::error::eof) {
+            log_error << "Connection closed by IST peer\n";
+        }
+        log_error << "got asio system error while reading IST stream: "
+                  << e.code() << " ec: " << ec << " what: " << e.what();
     }
     catch (gu::Exception& e)
     {
@@ -1114,11 +1217,12 @@ void galera::ist::AsyncSenderMap::run(const gu::Config&   conf,
                                       wsrep_seqno_t const first,
                                       wsrep_seqno_t const last,
                                       wsrep_seqno_t const preload_start,
-                                      int const           version)
+                                      int const           version,
+                                      const std::string&  sender_id)
 {
     gu::Critical crit(monitor_);
     AsyncSender* as(new AsyncSender(conf, peer, first, last, preload_start,
-                                    *this, version));
+                                    *this, version, sender_id));
     int err(gu_thread_create(&as->thread_, 0, &run_async_sender, as));
     if (err != 0)
     {
@@ -1140,6 +1244,34 @@ void galera::ist::AsyncSenderMap::remove(AsyncSender* as, wsrep_seqno_t seqno)
     senders_.erase(i);
 }
 
+void galera::ist::AsyncSenderMap::terminate(const std::vector<std::string>& active_peers) 
+{
+    gu::Critical crit(monitor_);
+    std::vector<AsyncSender*> senders_to_remove;
+    for(auto sender : senders_)
+    {
+        auto it = std::find(begin(active_peers), end(active_peers), sender->peer_id());
+        if (it == active_peers.end()) {
+            log_warn << "Peer (IST receiver) " << sender->peer_id().c_str()
+                     << " for IST AsyncSender seems to be disconnected."
+                     << " Terminating IST AsyncSender.\n",
+            senders_to_remove.push_back(sender);
+        }
+    }
+
+    for (auto sender : senders_to_remove) {
+        senders_.erase(sender);
+        int err;
+        sender->terminate();
+        monitor_.leave();
+        if ((err = gu_thread_join(sender->thread_, 0)) != 0)
+        {
+            log_warn << "thread_join() failed: " << err;
+        }
+        monitor_.enter();
+        delete sender;
+    }
+}
 
 void galera::ist::AsyncSenderMap::cancel()
 {

--- a/galera/src/ist.hpp
+++ b/galera/src/ist.hpp
@@ -149,6 +149,18 @@ namespace galera
                 }
             }
 
+            void terminate()
+            {
+                if (use_ssl_ == true)
+                {
+                    ssl_stream_->lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both);
+                }
+                else
+                {
+                    socket_.shutdown(asio::socket_base::shutdown_type::shutdown_both);
+                }
+            }
+
         private:
 
             asio::io_service                          io_service_;
@@ -190,9 +202,11 @@ namespace galera
                      wsrep_seqno_t first,
                      wsrep_seqno_t last,
                      wsrep_seqno_t preload_start,
-                     int           version);
+                     int           version,
+                     const std::string& sender_id);
 
             void remove(AsyncSender*, wsrep_seqno_t);
+            void terminate(const std::vector<std::string>& active_peers);
             void cancel();
             gcache::GCache& gcache() { return gcache_; }
         private:

--- a/galera/src/replicator.hpp
+++ b/galera/src/replicator.hpp
@@ -113,7 +113,8 @@ namespace galera
         virtual void process_state_req(void* recv_ctx, const void* req,
                                        size_t req_size,
                                        wsrep_seqno_t seqno_l,
-                                       wsrep_seqno_t donor_seq) = 0;
+                                       wsrep_seqno_t donor_seq,
+                                       const char *requestor_id) = 0;
         virtual void process_join(wsrep_seqno_t seqno, wsrep_seqno_t seqno_l) =0;
         virtual void process_sync(wsrep_seqno_t seqno_l) = 0;
 

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -2632,12 +2632,13 @@ galera::ReplicatorSMM::process_conf_change(void*                    recv_ctx,
 void galera::ReplicatorSMM::drain_monitors_for_local_conf_change(const gcs_act_cchange& cc)
 {
    std::vector<std::string> allowed_IST_clients;
+   allowed_IST_clients.reserve(cc.memb.size());
+
    for ( auto member : cc.memb) {
        char tmp[GU_UUID_STR_LEN+1];
        gu_uuid_print(&(member.uuid_), tmp, GU_UUID_STR_LEN);
        tmp[GU_UUID_STR_LEN] = 0;
-       std::string uuid(tmp);
-       allowed_IST_clients.push_back(uuid);
+       allowed_IST_clients.emplace_back(tmp);
    }
    ist_senders_.terminate(allowed_IST_clients);
 
@@ -2645,7 +2646,7 @@ void galera::ReplicatorSMM::drain_monitors_for_local_conf_change(const gcs_act_c
         log_info << "Maybe drain monitors from " << last_committed()
                   << " upto current CC event " << cc.seqno
                   << " upto:" << upto;
-
+    assert(upto >= last_committed());
     if (upto >= last_committed())
     {
         log_info << "Drain monitors from " << last_committed()

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -148,7 +148,7 @@ namespace galera
         void process_conf_change(void* recv_ctx, const struct gcs_action& cc);
         void process_state_req(void* recv_ctx, const void* req,
                                size_t req_size, wsrep_seqno_t seqno_l,
-                               wsrep_seqno_t donor_seq);
+                               wsrep_seqno_t donor_seq, const char* requestor_id);
         void process_join(wsrep_seqno_t seqno, wsrep_seqno_t seqno_l);
         void process_sync(wsrep_seqno_t seqno_l);
         void process_vote(wsrep_seqno_t seq, int64_t code,wsrep_seqno_t seqno_l);

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -415,7 +415,8 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                                       const void* req,
                                       size_t      req_size,
                                       wsrep_seqno_t const seqno_l,
-                                      wsrep_seqno_t const donor_seq)
+                                      wsrep_seqno_t const donor_seq,
+                                      const char* requestor_id)
 {
     assert(recv_ctx != 0);
     assert(seqno_l > -1);
@@ -515,7 +516,7 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                                 * with the global replicator protocol.
                                 * Need to keep it that way for backward
                                 * compatibility */
-                               protocol_version_);
+                               protocol_version_, std::string(requestor_id));
               // seqno will be unlocked when sender exists
               seqno_lock_guard.unlock_ = false;
             } catch (gu::Exception &e) {
@@ -604,7 +605,8 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                                       * with the global replicator protocol.
                                       * Need to keep it that way for backward
                                       * compatibility */
-                                     protocol_version_);
+                                     protocol_version_,
+                                     std::string(requestor_id));
                     // seqno will be unlocked when sender exists
                     seqno_lock_guard.unlock_ = false;
                 }

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -2178,6 +2178,12 @@ long gcs_recv (gcs_conn_t*        conn,
         action->type    = recv_act->rcvd.act.type;
         action->seqno_g = recv_act->rcvd.id;
         action->seqno_l = recv_act->local_id;
+        if (gu_likely(recv_act->rcvd.sender_id[0] == 0)) {
+            action->sender_id[0] = 0;
+        } else {
+            memcpy(action->sender_id, recv_act->rcvd.sender_id, GU_UUID_STR_LEN);
+            action->sender_id[GU_UUID_STR_LEN] = 0;
+        }
 
         if (gu_unlikely (GCS_ACT_CCHANGE == action->type)) {
             err = gu_fifo_cancel_gets (conn->recv_q);

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -212,6 +212,7 @@ struct gcs_action {
     const void*    buf; /*! unlike input, output goes as a single buffer */
     int32_t        size;
     gcs_act_type_t type;
+    char           sender_id[GU_UUID_STR_LEN+1];
 };
 
 std::ostream& operator <<(std::ostream& os, const gcs_action& act);

--- a/gcs/src/gcs_act.hpp
+++ b/gcs/src/gcs_act.hpp
@@ -29,7 +29,10 @@ struct gcs_act_rcvd
     const struct gu_buf* local; // local buffer vector if any
     gcs_seqno_t    id;          // global total order seqno
     int            sender_idx;
-    gcs_act_rcvd() : act(), local(NULL), id(GCS_SEQNO_ILL), sender_idx(-1) { }
+    char           sender_id[GU_UUID_STR_LEN + 1];
+    gcs_act_rcvd() : act(), local(NULL), id(GCS_SEQNO_ILL), sender_idx(-1) {
+        sender_id[0] = 0;
+    }
     gcs_act_rcvd(const gcs_act& a, const struct gu_buf* loc,
                  gcs_seqno_t i, int si)
         :
@@ -37,7 +40,9 @@ struct gcs_act_rcvd
         local(loc),
         id(i),
         sender_idx(si)
-    { }
+    {
+        sender_id[0] = 0;
+    }
 };
 
 #endif /* _gcs_act_h_ */

--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -2040,6 +2040,16 @@ gcs_group_handle_state_request (gcs_group_t*         group,
         // see gcs_request_state_transfer()
     }
 
+    // Append requesting node ID to the request.
+    // We do it here because we need joiner's uuid ONLY to pass it to
+    // IST AsyncSender instance to be able to match later the AsyncSender with
+    // the particular IST peer (pxc node).
+    // It could be done in gcs_recv_thread() where action is added to the
+    // connection queue, but it would add unnecessary overhead for actions that
+    // don't need this information (most of the actions)
+    memcpy(act->sender_id, group->nodes[joiner_idx].id, GU_UUID_STR_LEN);
+    act->sender_id[GU_UUID_STR_LEN] = 0;
+
     // Return index of donor (or error) in the seqno field to sender.
     // It will be used to detect error conditions (no availabale donor,
     // donor crashed and the like).


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3580

node_1 - IST sender
node_2 - IST receiver

Problem on the donor side:
node_2 partitioned after receiving IST, but before processing all WSs
and signaling node_1 that it finished.

1. node_2 partitioned
2. node_1 tries to reconnect to node_2, and while it is not possible
within evs.suspect_timeout/evs.inactive_timeout, the node is declared as
inactive
3. node_2 becomes available again
4. node_2 requests for IST
5. node_1 starts AsyncSender (it locks GCache, which will be unlocked
when AsyncSender finishes), node_2 starts Receiver.
6. IST is being sent node_1 -> node_2. node_2 buffers all writesets in
the queue which is processed by node_2's replication threads.
8. There is no SST so node_1 shifts its state DONOR -> JOINED -> SYNCED
and processes process_commit_cut seq() which triggers async action
(ServiceThd) of release_seqno(). It cannot be released, as AsyncSender
is having GCache lock.
7. All WSs are transferred, however AsycSender waits for Receiver to
close the connection (AsyncSender::send() => send_eof()) holding GCache
lock.
9. node_2 partitioned again
10. node_1 tries to reconnect again and node_2 gets removed from the
cluster
11. CC is processed by node_1. Certification position
is being adjusted and ServiceThd::flush is called. It blocks, as we
already have pending release_seqno().
12. process_conf_change enters local_monitor_ with CC seqno
13. ReplicatorSMM::process_prim_conf_change() is called, certification
position is adjusted. GCache release_seqno is requested (async action
done by service_thd_). However, this action is blocked, because GCache
is locked by IST AsyncSender that was for node_2. So we wait on flush,
having local_monitor_ entered.
14. Query from the client is executed. It gets into the certification
stage and attempts to enter local_monitor_
(enter_local_monitor_for_cert), but is blocked.

Solution:
When node_2 is being partitioned, AsyncSender associated with this node
should be unconditionally terminated.

Problem on the joiner side:
1. on node_2 Receiver::run() uses synchronous socket reads to get WSs
from donor.
2. node_2 partitioned
3. node_1 detects the problem, closes AsyncSender
4. node_2 waits infinitely for data from node_1

Solution:
It would be better to use async socket read together with a timer.
Unfortunately, we are not using boost asio. Additionally, it would need
deeper refactoring, testing.
Instead of huge changes, SocketWatchdog was introduced which
terminates the socket (and the whole Receiver) if no data is received
within 10 seconds.
In such a case node_2 restart is required, but this is yet another
existing issue (by design) that if node_2 didn't receive all WSs
expected, it self-leaves the cluster with an appropriate message in
the error log.