### PR TITLE
PXC-3584 : Assertion failure: lock0lock.cc:6588:!(&trx->mutex)->is_ow…

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1191,6 +1191,9 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandleMaster& trx,
             assert(trx.owned());
             bool unused(false);
             lock.unlock();
+
+            GU_DBUG_SYNC_WAIT("start_of_replay_trx");
+
             gu_trace(ts.apply(trx_ctx, apply_cb_, meta, unused));
             lock.lock();
             assert(false == unused);


### PR DESCRIPTION
…ned()

https://jira.percona.com/browse/PXC-3584

When does replaying of trx happen?

1. Two transactions that are not conflicting at certification level but
   are conflicting at trx commit can lead to situation where one trx
   can be replayed.
2. Trx is replayed only if Victim will have higher seqno than the trx
   that initiated the abort
3. During the replay, before replay is initiated, if a new trx holds
   locks that will be required by replayed trx, replayed trx will try
   to BF Abort the new trx that is open and uncommitted

Problem:
--------
When a trx is about to be replayed and if there exists a conflicting
transaction, the replaying trx will try to BF Abort the conflicting
trx.

During this BF-Abort, an assertion occured because replaying trx
didn't set the BF-abort thread id.

Fix:
----
Replaying transactions should set proper thread id to do BF Aborts.