### PR TITLE
PXC-3685: Log is spammed with messages

### DIFF
--- a/galera/src/ist.cpp
+++ b/galera/src/ist.cpp
@@ -786,7 +786,7 @@ void galera::ist::Receiver::run()
                         ts->mark_dummy_with_action(act.buf);
                     }
 
-                    log_info << "####### Passing WS " << act.seqno_g;
+                    log_debug << "####### Passing WS " << act.seqno_g;
                     handler_.ist_trx(ts, must_apply, preload);
                     break;
                 }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3685

Decreased log verbosity for message informing about writesets processed
during IST.