### PR TITLE
PXC-3774: Relax seqno assertion in replicator_smm

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -3201,7 +3201,7 @@ void galera::ReplicatorSMM::process_prim_conf_change(void* recv_ctx,
     }
 
     // From this point on the CC is known to be processed in order.
-    assert(group_seqno > cert_.position());
+    assert(group_seqno >= cert_.position());
 
     // This CC is processed in order. Establish protocol versions,
     // it must be done before cert_.adjust_position().


### PR DESCRIPTION
Issue: PXC could crash with this assertion during a 5.7 -> 8.0 upgrade
if no changes were written to the cluster between shutting down the 5.7
node and starting the 8.0 node.

The assertion assumes that the seqno has to increase with the CC event,
but when a node is upgraded equality is also valid in the above
scenario.

Fix: relaxed the assertion to allow for equality, preventing the
5.7->8.0 upgrade from crashing debug buils.