### PR TITLE
PXC-3918: Connection timeout issue with garbd in 8.0.27

### DIFF
--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -151,6 +151,20 @@ Config::Config (int argc, char* argv[])
     if (options_.length() > 0) options_ += "; ";
     options_ += "gcs.fc_limit=9999999; gcs.fc_factor=1.0; gcs.fc_master_slave=yes";
 
+    // Add implicit socket.ssl=YES if needed.
+    // We need to add it if socket.ssl_key or socket.ssl_cert is specified
+    // and socket.ssl is not specified.
+    // This is the same logic as Galera does in gu_asio.cpp::init_use_ssl()
+    if ((options_.find("socket.ssl_key") != std::string::npos ||
+         options_.find("socket.ssl_cert") != std::string::npos)
+         &&
+         // this way we avoid tokenizing and stripping the string
+        (options_.find("socket.ssl=") == std::string::npos &&
+         options_.find("socket.ssl ") == std::string::npos))
+    {
+        options_ += "; socket.ssl=YES";
+    }
+
     // this block must be the very last.
     gu_conf_self_tstamp_on();
     if (vm.count("log"))


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3918

Problem:
If PXC server uses encrypted connections, garbd is not able to connect
even if proper certificates are specified.

Cause:
Galera commit c27596d06a221f6c14d36759c681149964008749 refactored asio
layer. As the part of this refactor the logic present in
asio_protonet.cpp:gcomm::AsioProtonet::AsioProtonet() responsible for
implicit setting socket.ssl=YES option was removed.

Galera still works, because it still has similar logic in
gu_asio.cpp:init_use_ssl(). Garbd however does not use the layer
provided by gu_asio.cpp.

As the result gcomm layer is initialized withotu socket.ssl=YES
for garbd.

Solution:
Add logic similar to Galera's one of implicit additon of socket.ssl=YES
into garbd.