### PR TITLE
PXC-3909: Fix garbd instability issues

### DIFF
--- a/garb/garb_gcs.cpp
+++ b/garb/garb_gcs.cpp
@@ -170,8 +170,8 @@ Gcs::close (bool explicit_close)
     }
 }
 
-gcs_node_state_t Gcs::state_for(ssize_t idx) {
-  return gcs_get_state_for_idx(gcs_, idx);
+gcs_node_state_t Gcs::state_for(gu_uuid_t uuid) {
+  return gcs_get_state_for_uuid(gcs_, uuid);
 }
 
 } /* namespace garb */

--- a/garb/garb_gcs.hpp
+++ b/garb/garb_gcs.hpp
@@ -33,7 +33,7 @@ public:
 
     int  proto_ver() const { return gcs_proto_ver(gcs_); }
 
-    gcs_node_state_t state_for(ssize_t idx);
+    gcs_node_state_t state_for(gu_uuid_t uuid);
 
     void close (bool explicit_close = false);
 

--- a/garb/garb_recv_loop.cpp
+++ b/garb/garb_recv_loop.cpp
@@ -76,12 +76,13 @@ RecvLoop::loop()
     std::thread sst_out_log;
     std::thread sst_err_log;
 
-    ssize_t sst_source = 0;
+    gu_uuid_t sst_source_uuid;
     bool sst_requested = false;
     std::atomic_bool sst_status_keep_running{true};
     std::thread sst_status_thread;
 
     bool sst_ended = false;
+    bool sst_terminated = false;
     while (1)
     {
         gcs_action act;
@@ -121,7 +122,8 @@ RecvLoop::loop()
                     uuid_  = cc.uuid;
                     seqno_ = cc.seqno;
                     sst_requested = true;
-                    sst_source =  gcs_.request_state_transfer (config_.sst(),config_.donor());
+                    auto sst_source_idx =  gcs_.request_state_transfer (config_.sst(),config_.donor());
+                    sst_source_uuid = cc.memb[sst_source_idx].uuid_;
                     if(config_.recv_script().empty()) {
                         gcs_.join(gu::GTID(cc.uuid, cc.seqno), 0);
                     } else {
@@ -141,12 +143,20 @@ RecvLoop::loop()
 
                         sst_status_thread = std::thread([&](){
                             while(sst_status_keep_running) {
-                              auto st = gcs_.state_for(sst_source);
-                              if(st != GCS_NODE_STATE_DONOR) {
+
+                              auto st = gcs_.state_for(sst_source_uuid);
+                              if(st == GCS_NODE_STATE_MAX) {
+                                  log_info << "Donor is no longer in the cluster, interrupting script";
+                                  sst_terminated = true;
+                                  p.terminate();
+                                  break;
+                              } else if(st != GCS_NODE_STATE_DONOR) {
                                   // The donor is going back to SYNCED. If SST streaming didn't start yet,
                                   // it won't.
-                                  // Send SIGINT to the script and let it handle this situation.
-                                  p.interrupt();
+                                  // Send SIGTERM to the script and let it handle this situation.
+                                  log_info << "Donor no longer in donor state, interrupting script";
+                                  sst_terminated = true;
+                                  p.terminate();
                                   break;
                               }
                               std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -162,7 +172,15 @@ RecvLoop::loop()
                 if (cc.memb.size() == 0) // SELF-LEAVE after closing connection
                 {
                     if(!config_.recv_script().empty()) {
-                        if(sst_ended) {
+                      if (sst_terminated) {
+                            log_info << "SST script already terminated";
+                            sst_err_log.join();
+                            sst_out_log.join();
+                            sst_status_keep_running = false;
+                            sst_status_thread.join();
+                            log_info << "Exiting main loop";
+                            return 1;
+                        } else if(sst_ended) {
                             // Good path: we decided to close the connection after the receiver script closed its
                             // standard output. We wait for it to exit and return its error code.
                             log_info << "Waiting for SST script to stop";

--- a/garb/garb_recv_loop.cpp
+++ b/garb/garb_recv_loop.cpp
@@ -174,12 +174,13 @@ RecvLoop::loop()
                     if(!config_.recv_script().empty()) {
                       if (sst_terminated) {
                             log_info << "SST script already terminated";
+                            const auto ret = p.wait();
                             sst_err_log.join();
                             sst_out_log.join();
                             sst_status_keep_running = false;
                             sst_status_thread.join();
                             log_info << "Exiting main loop";
-                            return 1;
+                            return ret;
                         } else if(sst_ended) {
                             // Good path: we decided to close the connection after the receiver script closed its
                             // standard output. We wait for it to exit and return its error code.

--- a/garb/process.cc
+++ b/garb/process.cc
@@ -91,7 +91,7 @@ void process::execute(const char *type, char **env) {
   int const child_end(parent_end == PIPE_READ ? PIPE_WRITE : PIPE_READ);
   int const close_fd(parent_end == PIPE_READ ? STDOUT_FD : STDIN_FD);
 
-  char *const pargv[4] = {strdup("sh"), strdup("-c"), strdup(str_), NULL};
+  char *const pargv[4] = {strdup("bash"), strdup("-c"), strdup(str_), NULL};
 
   // Create the second pipe (needed only if type = "rw")
   // One pipe for reading and one pipe for writing

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -238,10 +238,18 @@ struct gcs_conn
     gu::Progress<gcs_seqno_t>* progress_;
 };
 
-gcs_node_state_t gcs_get_state_for_idx(gcs_conn_t* conn, ssize_t idx) {
+gcs_node_state_t gcs_get_state_for_uuid(gcs_conn_t* conn, gu_uuid_t uuid) {
+  std::stringstream ss;
+  ss << uuid;
+
   auto group = gcs_core_get_group(conn->core);
-  auto& node = group->nodes[idx];
-  return node.status;
+  for(int idx = 0; idx < group->num; ++idx) {
+    auto const& node = group->nodes[idx];
+    if(ss.str() == node.id) {
+      return node.status;
+    }
+  }
+  return GCS_NODE_STATE_MAX; // node gone
 }
 
 // Oh C++, where art thou?

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -516,7 +516,7 @@ extern void gcs_join_notification(gcs_conn_t *conn);
 extern void
 gcs_fetch_pfs_info (gcs_conn_t* conn, wsrep_node_info_t* entries, uint32_t size);
 
-gcs_node_state_t gcs_get_state_for_idx(gcs_conn_t* conn, ssize_t idx);
+gcs_node_state_t gcs_get_state_for_uuid(gcs_conn_t* conn, gu_uuid_t uuid);
 #endif /* PXC */
 
 /*! A node with this name will be treated as a stateless arbitrator */


### PR DESCRIPTION
This commit addresses two different issues which could result in failed
backups:

* Garbd saved the index of the SST donor node after the SST started, and
  used this index later to check the progress of the SST transfer.
  However changes in the cluster during the SST process can result in
  the donor node moving in the array representing the cluster, resulting
  in aborting an otherwise progressing backup, or garbd crashing.
  This commit changes garbd to use the UUID for backups instead, solving
  the issue.
* The signal handling in the backup script could fail if /bin/sh doesn't
  point to bash. Dash for example seems to ignore sigint when executed
  by garbd, and the bash started by it inherits this behavior.
  To fix this, we change garbd to send a SIGTERM instead of
  SIGINT, which seems to work in both shells.

As a consequence, backup scripts should trap SIGTERM instead of SIGINT -
both, if backwards compatibility is required.