### PR TITLE
Backport PXC-3076: Galera build doesn't work with Python 3 (5.6)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -201,10 +201,6 @@ if link != 'default':
 cc_version = str(read_first_line(env['CC'].split() + ['--version']))
 cxx_version = str(read_first_line(env['CXX'].split() + ['--version']))
 
-if python_ver >= 3:
-    cc_version = cc_version.decode()
-    cxx_version = cxx_version.decode()
-
 print('Using C compiler executable: ' + env['CC'])
 print('C compiler version is: ' + cc_version)
 print('Using C++ compiler executable: ' + env['CXX'])


### PR DESCRIPTION
Issue:
The main SConstruct contains an incorrect Python 3 specific code
and results in an error.

  AttributeError: 'str' object has no attribute 'decode'

Fix:
Remove the python3 specific code and everything works with all scons
versions tested

(cherry picked from commit a3bc6ec232e7cc8ad5dba5f44898e007fb587725)