### PR TITLE
PXC-3962: PXC cross version replication fails between 5.7 and 8.0

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -3078,7 +3078,7 @@ void galera::ReplicatorSMM::process_prim_conf_change(void* recv_ctx,
                                                      int const my_index,
                                                      void* cc_buf)
 {
-    assert(conf.seqno > 0);
+    assert(conf.seqno >= 0);
     assert(my_index >= 0);
 
     GU_DBUG_SYNC_WAIT("process_primary_configuration");


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3962

Problem
-------
In debug builds, joining the 8.0 node to a freshly started 5.7 cluster
results in the assertion failure.

    void galera::ReplicatorSMM::process_prim_conf_change(void*, const
    gcs_act_cchange&, int, void*): Assertion `conf.seqno > 0' failed.

Analysis
--------
This assertion expects the seqno received from the CC to be greater than
zero. However this assertion makes sense only when the donor is on 8.0.
In 8.0, a new global seqno with view_info is generated when any node
joins or leaves the cluster. As a result, when the 8.0 node is started
freshly, galera generates the view_info that the first node joined the
cluster and assigns the seqno 1. So, when a new node joins the freshly
started 8.0 node, it always receives seqno=1 in the CC.

However, 5.7 does not generate the global seqno when a node joins or
leaves the cluster. As a result, when 8.0 node joins the freshly started
5.7 cluster, the seqno no in CC can be 0 and this triggerred the assert
  on 8.0 node.

Solution
--------
The assert condition has been relaxed.