### PR TITLE
PXC-3990: Building galera using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,11 +99,16 @@ include(cmake/maintainer_mode.cmake)
 
 include(CTest)
 enable_testing()
+
+if(DEFINED WITH_PERFSCHEMA_STORAGE_ENGINE)
+  add_definitions(-DHAVE_PSI_INTERFACE=1)
+endif()
+
 add_subdirectory(galerautils)
+add_subdirectory(garb)
 add_subdirectory(gcomm)
 add_subdirectory(gcache)
 add_subdirectory(gcs)
-add_subdirectory(garb)
 add_subdirectory(galera)
 add_subdirectory(scripts/packages)
 add_subdirectory(wsrep/tests)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -37,7 +37,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #
 
 # C flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -g")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -g -Wno-vla")
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=600")
 endif()

--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -185,10 +185,10 @@ check_against(const galera::KeyEntryNG*   const found,
                          << " for key " << key << ": "
                          << *trx << " <---> " << *ref_trx;
             }
-            /* fall through */
+            __attribute__((fallthrough));
         case DEPENDENCY:
             depends_seqno = std::max(ref_trx->global_seqno(), depends_seqno);
-            /* fall through */
+            __attribute__((fallthrough));
         case NOTHING:;
         }
     }

--- a/galera/src/ist_proto.hpp
+++ b/galera/src/ist_proto.hpp
@@ -699,7 +699,7 @@ namespace galera
                     case Message::T_CCHANGE:
                         act.buf  = wbuf;           // not skip
                         act.size = wsize;
-                        // fall through
+                        __attribute((fallthrough));
                     case Message::T_SKIP:
                         act.seqno_g = msg.seqno(); // not EOF
                         act.type    = gcs_type;

--- a/galera/src/key_os.hpp
+++ b/galera/src/key_os.hpp
@@ -235,7 +235,7 @@ namespace galera
         {
         case 2:
             os << std::hex << static_cast<int>(key.flags()) << " ";
-            // Fall through
+            __attribute((fallthrough));
         case 1:
         {
             std::deque<KeyPartOS> dq(key.key_parts<std::deque<KeyPartOS> >());

--- a/galera/src/key_set.hpp
+++ b/galera/src/key_set.hpp
@@ -231,7 +231,7 @@ public:
 #else
                 ret = (lhs[2] == rhs[2] && lhs[3] == rhs[3]);
 #endif /* WORDSIZE */
-                /* fall through */
+                __attribute((fallthrough));
             case FLAT8:
             case FLAT8A:
                 /* shift is to clear up the header */

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -346,7 +346,7 @@ galera::ReplicatorSMM::~ReplicatorSMM()
     case S_DONOR:
         start_closing();
         wait_for_CLOSED(lock);
-        // fall through
+        __attribute__((fallthrough));
     case S_CLOSED:
         ist_senders_.cancel();
         break;
@@ -1025,7 +1025,7 @@ galera::ReplicatorSMM::abort_trx(TrxHandleMaster& trx, wsrep_seqno_t bf_seqno,
     case TrxHandle::S_ROLLING_BACK:
         log_error << "Attempt to enter commit monitor while holding "
             "locks in rollback by " << trx;
-        // fallthrough
+        __attribute__((fallthrough));
     default:
         log_warn << "invalid state " << trx.state()
                  << " in abort_trx for trx"
@@ -1156,7 +1156,7 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandleMaster& trx,
             assert(ts.is_dummy());
             break;
         }
-        // fall through
+        __attribute__((fallthrough));
     case TrxHandle::S_CERTIFYING:
     {
         assert(ts.state() == TrxHandle::S_CERTIFYING);
@@ -1165,8 +1165,8 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandleMaster& trx,
         assert(apply_monitor_.entered(ao) == false);
         gu_trace(apply_monitor_.enter(ao));
         TX_SET_STATE(ts, TrxHandle::S_APPLYING);
+        __attribute__((fallthrough));
     }
-    // fall through
     case TrxHandle::S_APPLYING:
         //
         // Commit monitor will be entered from commit_order_enter_remote.
@@ -3750,7 +3750,7 @@ void galera::ReplicatorSMM::enter_apply_monitor_for_local_not_committing(
     {
     case TrxHandle::S_REPLICATING:
         TX_SET_STATE(ts, TrxHandle::S_CERTIFYING);
-        // fall through
+        __attribute__((fallthrough));
     case TrxHandle::S_CERTIFYING:
     {
         ApplyOrder ao(ts);

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -806,7 +806,7 @@ namespace galera
                     return is_local_;
 #endif /* PXC */
                     // in case of remote trx fall through
-                    // fall through
+                    __attribute__((fallthrough));
                 case NO_OOOC:
                     return (last_left + 1 == global_seqno_);
                 }

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -28,7 +28,7 @@ using galera::TrxHandleLock;
 
 
 extern "C" {
-    const char* wsrep_interface_version = (char*)WSREP_INTERFACE_VERSION;
+    const char* wsrep_interface_version = (const char*)WSREP_INTERFACE_VERSION;
 }
 
 

--- a/galera/tests/data_set_check.cpp
+++ b/galera/tests/data_set_check.cpp
@@ -81,7 +81,7 @@ private:
     const char* const       str_;
     bool const              own_;
 
-    ssize_t my_serial_size () const { return size_; };
+    ssize_t my_serial_size () const { return size_; }
 
     ssize_t my_serialize_to (void* buf, ssize_t size) const
     {

--- a/galerautils/src/gu_abort.c
+++ b/galerautils/src/gu_abort.c
@@ -6,7 +6,10 @@
  * $Id$
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+
 #include "gu_abort.h"
 
 #include "gu_system.h"

--- a/galerautils/src/gu_alloc.hpp
+++ b/galerautils/src/gu_alloc.hpp
@@ -80,7 +80,7 @@ private:
               left_    (size)
         {}
 
-        virtual ~Page() {};
+        virtual ~Page() {}
 
         byte_t* alloc (size_t size)
         {

--- a/galerautils/src/gu_asio.cpp
+++ b/galerautils/src/gu_asio.cpp
@@ -399,7 +399,7 @@ static void ssl_prepare_context(const gu::Config& conf, asio::ssl::context& ctx,
         {
             throw_last_SSL_error("SSL_CTX_set_ecdh_auto() failed");
         }
-#elif defined(OPENSSL_HAS_SET_TMP_ECDH)
+#elif defined(OPENSSL_HAS_SET_TMP_ECDH) && OPENSSL_VERSION_NUMBER < 0x10002000L
         {
             EC_KEY* const ecdh(EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
             if (ecdh == NULL)

--- a/galerautils/src/gu_asio_stream_engine.cpp
+++ b/galerautils/src/gu_asio_stream_engine.cpp
@@ -56,8 +56,9 @@ public:
         {
             return op_result{eof, 0};
         }
-        else if (errno == EAGAIN || errno == EWOULDBLOCK)
+        else if (errno == EAGAIN)
         {
+            static_assert(EAGAIN == EWOULDBLOCK, "EAGAIN and EWOULDBLOCK are the same");
             return op_result{want_read, 0};
         }
         else
@@ -75,8 +76,9 @@ public:
         {
             return op_result{success, static_cast<size_t>(bytes_written) };
         }
-        else if (errno == EAGAIN || errno == EWOULDBLOCK)
+        else if (errno == EAGAIN)
         {
+            static_assert(EAGAIN == EWOULDBLOCK, "EAGAIN and EWOULDBLOCK are the same");
             return op_result{want_write, 0};
         }
         else

--- a/galerautils/src/gu_asio_stream_react.cpp
+++ b/galerautils/src/gu_asio_stream_react.cpp
@@ -413,7 +413,7 @@ void gu::AsioStreamReact::server_handshake_handler(
         break;
     case AsioStreamEngine::error:
         log_warn << "Handshake failed: " << engine_->last_error();
-        // Fall through
+        __attribute__((fallthrough));
     case AsioStreamEngine::eof:
         // Restart accepting transparently. The socket will go out of
         // scope and will be destructed.
@@ -931,7 +931,7 @@ void gu::AsioAcceptorReact::accept_handler(
     case AsioStreamEngine::error:
         log_warn << "Handshake failed: "
                  << socket->engine_->last_error();
-        // Fall through
+        __attribute__((fallthrough));
     case AsioStreamEngine::eof:
         // Continue accepting transparently if socket handshake fails.
         // From user handler point of view this connection never existed

--- a/galerautils/src/gu_dbug.h
+++ b/galerautils/src/gu_dbug.h
@@ -116,7 +116,8 @@ extern "C"
     extern void  _gu_db_pargs_  (uint _line_,
                                  const char* keyword);
     extern void  _gu_db_doprnt_ (const char* format,
-                                 ...);
+                                 ...)
+                                __attribute__ ((format (printf, 1, 0)));
     extern void  _gu_db_dump_   (uint _line_,
                                  const char *keyword,
                                  const char *memory,

--- a/galerautils/src/gu_deqmap.hpp
+++ b/galerautils/src/gu_deqmap.hpp
@@ -91,7 +91,7 @@ public:
     ~DeqMap()
     {
         GU_DEQMAP_ASSERT_CONSISTENCY;
-    };
+    }
 
     /** total number of elements allocated (not all of them set) */
     size_type size()  const { return base_.size();  }

--- a/galerautils/src/gu_init.c
+++ b/galerautils/src/gu_init.c
@@ -29,7 +29,7 @@ gu_init (gu_log_cb_t log_cb)
     size_t const page_size = GU_PAGE_SIZE;
     if (page_size & (page_size - 1))
     {
-        gu_fatal("GU_PAGE_SIZE(%z) is not a power of 2", GU_PAGE_SIZE);
+        gu_fatal("GU_PAGE_SIZE(%zu) is not a power of 2", GU_PAGE_SIZE);
         gu_abort();
     }
 

--- a/galerautils/src/gu_lock.hpp
+++ b/galerautils/src/gu_lock.hpp
@@ -34,7 +34,7 @@ namespace gu
 
         Lock (const Mutex& mtx) : mtx_(&mtx)
 #ifdef PXC
-#if HAVE_PSI_INTERFACE
+#ifdef HAVE_PSI_INTERFACE
             , pfs_mtx_()
 #endif
 #endif /* PXC */

--- a/galerautils/src/gu_log.c
+++ b/galerautils/src/gu_log.c
@@ -133,6 +133,7 @@ gu_log (gu_log_severity_t severity,
         const char*       file,
         const char*       function,
         const int         line,
+        const char*       format,
         ...)
 {
     va_list ap;
@@ -163,10 +164,8 @@ gu_log (gu_log_severity_t severity,
 
         str += len;
         max_string -= len;
-        va_start (ap, line);
+        va_start (ap, format);
         {
-            const char* format = va_arg (ap, const char*);
-
             if (gu_likely(max_string > 0 && NULL != format)) {
                 vsnprintf (str, max_string, format, ap);
             }

--- a/galerautils/src/gu_log.h
+++ b/galerautils/src/gu_log.h
@@ -54,7 +54,9 @@ gu_log (gu_log_severity_t severity,
         const char*       file,
         const char*       function,
         const int         line,
-        ...);
+        const char*       format,
+        ...)
+       __attribute__((format (printf, 5, 0)));
 
 /** This variable is made global only for the purpose of using it in
  *  gu_debug() macro and avoid calling gu_log() when debug is off.

--- a/galerautils/src/gu_rset.cpp
+++ b/galerautils/src/gu_rset.cpp
@@ -253,7 +253,8 @@ RecordSetOutBase::write_header (byte_t* const buf, ssize_t const size)
             /* zero up potential padding bytes */
             ::memset(buf + off + 4, 0, hdr_size - 8);
         }
-        /* fall through *//* to uleb encoding */
+        buf[off+4] = 0;
+        __attribute__((fallthrough));
     case VER1:
         buf[off] = ver_byte; off += 1;
         off += uleb128_encode(size_, buf + off, size - off);

--- a/galerautils/src/gu_rset.hpp
+++ b/galerautils/src/gu_rset.hpp
@@ -64,7 +64,7 @@ public:
     CheckType check_type() const { return CheckType(check_type_); }
 
     /*! return alignment of the records */
-    int       alignment()  const { return alignment_; };
+    int       alignment()  const { return alignment_; }
 
     typedef gu::Vector<gu::Buf, 16> GatherVector;
 

--- a/galerautils/src/gu_signals.hpp
+++ b/galerautils/src/gu_signals.hpp
@@ -29,7 +29,7 @@ namespace gu
     private:
         Signals()
           : signal_()
-        { };
+        { }
         ~Signals() = default;
         signal_t signal_;
     };

--- a/galerautils/src/gu_string.hpp
+++ b/galerautils/src/gu_string.hpp
@@ -171,7 +171,7 @@ public:
     template <typename X>
     bool operator!= (const X& x) { return !operator==(x); }
 
-    void clear() { derived_clear(); };
+    void clear() { derived_clear(); }
 
     StringBase& operator= (const StringBase& other)
     {

--- a/galerautils/src/gu_system.h
+++ b/galerautils/src/gu_system.h
@@ -9,7 +9,10 @@
 #ifndef _gu_system_h_
 #define _gu_system_h_
 
-#define _GNU_SOURCE // program_invocation_name, program_invocation_short_name
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <errno.h>
 
 #include <stdlib.h> // getexecname, getprogname

--- a/galerautils/src/gu_vector.hpp
+++ b/galerautils/src/gu_vector.hpp
@@ -105,7 +105,7 @@ public:
         container().resize(n, val);
     }
 
-    void push_back (const value_type& val) { container().push_back(val); };
+    void push_back (const value_type& val) { container().push_back(val); }
 
           T& front()       { return container().front(); }
     const T& front() const { return container().front(); }

--- a/galerautils/tests/CMakeLists.txt
+++ b/galerautils/tests/CMakeLists.txt
@@ -35,6 +35,9 @@ target_compile_options(gu_tests
   -Wno-unused-parameter
   -Wno-declaration-after-statement
   -Wno-vla
+  -Wno-format-extra-args # check_if is deprecated, fails format checks
+  -Wno-format
+  -Wno-format-security
   )
 
 target_link_libraries(gu_tests galerautils ${GALERA_UNIT_TEST_LIBS})

--- a/galerautils/tests/gu_asio_test.cpp
+++ b/galerautils/tests/gu_asio_test.cpp
@@ -1249,7 +1249,7 @@ public:
     std::string scheme() const GALERA_OVERRIDE
     {
         return "mock";
-    };
+    }
     void assign_fd(int fd) GALERA_OVERRIDE
     {
         fd_ = fd;
@@ -1308,8 +1308,9 @@ public:
         {
             return {eof, size_t(result)};
         }
-        else if (errno == EAGAIN || errno == EWOULDBLOCK)
+        else if (errno == EAGAIN)
         {
+            static_assert(EAGAIN == EWOULDBLOCK);
             last_error_ = errno;
             return {return_on_block, size_t(result)};
         }

--- a/galerautils/tests/gu_digest_test.cpp
+++ b/galerautils/tests/gu_digest_test.cpp
@@ -204,7 +204,7 @@ START_TEST (gu_fast_hash_test)
 }
 END_TEST
 
-#if SKIP_TABLE_FUNCTIONS
+#ifdef SKIP_TABLE_FUNCTIONS
 
 /* Tests table hash functions:
  * - for 64-bit platforms table hash should be identical to fast 64-bit hash,

--- a/galerautils/tests/gu_rset_test.cpp
+++ b/galerautils/tests/gu_rset_test.cpp
@@ -86,7 +86,7 @@ private:
     const char* const       str_;
     bool const              own_;
 
-    ssize_t my_serial_size () const { return size_; };
+    ssize_t my_serial_size () const { return size_; }
 
     ssize_t my_serialize_to (void* buf, ssize_t size) const
     {

--- a/garb/CMakeLists.txt
+++ b/garb/CMakeLists.txt
@@ -32,6 +32,9 @@ target_compile_options(garbd
 target_link_libraries(garbd gcs4garb gcomm gcache
   ${Boost_PROGRAM_OPTIONS_LIBRARIES})
 
+set_target_properties( garbd PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+  ${CMAKE_CURRENT_BINARY_DIR}/../bin/ )
+
 install(TARGETS garbd DESTINATION bin)
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
   install(FILES

--- a/garb/garb_main.cpp
+++ b/garb/garb_main.cpp
@@ -119,9 +119,14 @@ main (int argc, char* argv[])
 
 } /* namespace garb */
 
+void pfs_noop(wsrep_pfs_instr_type_t, wsrep_pfs_instr_ops_t,
+              wsrep_pfs_instr_tag_t, void **, void **alliedvalue,
+              const void *ts) {}
+
 int
 main (int argc, char* argv[])
 {
+    gu_conf_set_pfs_instr_callback(pfs_noop);
     try
     {
         return garb::main (argc, argv);

--- a/gcache/src/gcache_mem_store.hpp
+++ b/gcache/src/gcache_mem_store.hpp
@@ -113,7 +113,12 @@ namespace gcache
 
             if (tmp)
             {
+#pragma GCC diagnostic push
+#if __GNUC__ > 12 || (__GNUC__ == 12 && __GNUC_MINOR__ >= 1)
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
                 allocd_.erase(bh);
+#pragma GCC diagnostic pop
                 allocd_.insert(tmp);
 
                 bh = BH_cast(tmp);
@@ -133,8 +138,8 @@ namespace gcache
             assert (BH_is_released(bh));
 
             size_ -= bh->size;
-            ::free (bh);
             allocd_.erase(bh);
+            ::free (bh);
         }
 
         void set_max_size (size_t size) { max_size_ = size; }

--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -1302,7 +1302,7 @@ namespace gcache
         size_t chain_count[] = { 0, 0, 0, 0 };
 
         chain_t chain(NONE);
-        const uint8_t* chain_start;
+        const uint8_t* chain_start = nullptr;
         size_t count;
 
         bool next(false);

--- a/gcomm/src/evs_proto.cpp
+++ b/gcomm/src/evs_proto.cpp
@@ -2689,7 +2689,7 @@ int gcomm::evs::Proto::handle_down(Datagram& wb, const ProtoDownMeta& dm)
         {
         case EAGAIN:
             output_.push_back(std::make_pair(wb, dm));
-            // fall through
+            __attribute__((fallthrough));
         case 0:
             ret = 0;
             break;

--- a/gcomm/test/check_trace.hpp
+++ b/gcomm/test/check_trace.hpp
@@ -302,9 +302,10 @@ namespace gcomm
 
         void connect(bool first)
         {
+            using namespace std::placeholders;
             gu_trace(std::for_each(protos_.rbegin(), protos_.rend(),
-                                   std::bind2nd(
-                                       std::mem_fun(&Protolay::connect), first)));
+                                   std::bind(
+                                       std::mem_fn(&Protolay::connect), _1, first)));
         }
 
         void close(bool force = false)
@@ -315,7 +316,7 @@ namespace gcomm
                 (*i)->close();
             }
             // gu_trace(std::for_each(protos.rbegin(), protos.rend(),
-            //                       std::mem_fun(&Protolay::close)));
+            //                       std::mem_fn(&Protolay::close)));
         }
 
 
@@ -327,7 +328,7 @@ namespace gcomm
                 (*i)->close(uuid);
             }
             // gu_trace(std::for_each(protos.rbegin(), protos.rend(),
-            //                       std::mem_fun(&Protolay::close)));
+            //                       std::mem_fn(&Protolay::close)));
         }
 
         void send()
@@ -420,7 +421,7 @@ namespace gcomm
         gu::datetime::Date handle_timers()
         {
             std::for_each(protos_.begin(), protos_.end(),
-                          std::mem_fun(&Protolay::handle_timers));
+                          std::mem_fn(&Protolay::handle_timers));
             return gu::datetime::Date::max();
         }
 

--- a/gcs/src/CMakeLists.txt
+++ b/gcs/src/CMakeLists.txt
@@ -58,8 +58,12 @@ target_link_libraries(gcs gcomm gcache)
 add_library(gcs4garb STATIC ${GCS_SOURCES})
 
 target_compile_definitions(gcs4garb
-  PRIVATE
+  PUBLIC
   -DGCS_FOR_GARB
+)
+
+target_compile_definitions(gcs4garb
+  PRIVATE
   -DGALERA_LOG_H_ENABLE_CXX
   -DGCS_USE_GCOMM
   )

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1232,7 +1232,7 @@ gcs_handle_state_change (gcs_conn_t*           conn,
                          const struct gcs_act* act)
 {
     gu_debug ("Got '%s' dated %lld", gcs_act_type_to_str (act->type),
-              gcs_seqno_gtoh(*(gcs_seqno_t*)act->buf));
+              gcs_seqno_gtoh(*(const gcs_seqno_t*)act->buf));
 
     void* buf = malloc (act->buf_len);
 
@@ -1240,7 +1240,7 @@ gcs_handle_state_change (gcs_conn_t*           conn,
         memcpy (buf, act->buf, act->buf_len);
         /* Initially act->buf points to internal static recv buffer.
          * No leak here. */
-        ((struct gcs_act*)act)->buf = buf;
+        const_cast<gcs_act*>(act)->buf = buf;
         return 1;
     }
     else {
@@ -1337,7 +1337,7 @@ gcs_handle_actions (gcs_conn_t* conn, struct gcs_act_rcvd& rcvd)
         break;
     case GCS_ACT_JOIN:
         ret = gcs_handle_state_change (conn, &rcvd.act);
-        if (gcs_seqno_gtoh(*(gcs_seqno_t*)rcvd.act.buf) < 0 &&
+        if (gcs_seqno_gtoh(*(const gcs_seqno_t*)rcvd.act.buf) < 0 &&
             GCS_CONN_JOINER == conn->state)
             gcs_become_primary (conn);
         else
@@ -2173,7 +2173,7 @@ long gcs_request_state_transfer (gcs_conn_t*    conn,
             offset = ist_gtid.serialize(rst, rst_size, offset);
             memcpy (rst + offset, req, size);
             assert(offset + size == rst_size);
-            log_debug << "SST sending: " << (char*)req << ", " << rst_size;
+            log_debug << "SST sending: " << (const char*)req << ", " << rst_size;
         }
 
         struct gcs_action action;
@@ -2244,7 +2244,7 @@ long gcs_recv (gcs_conn_t*        conn,
         bool send_cont  = gcs_fc_cont_begin   (conn);
         bool send_sync  = gcs_send_sync_begin (conn);
 
-        action->buf     = (void*)recv_act->rcvd.act.buf;
+        action->buf     = const_cast<void*>(recv_act->rcvd.act.buf);
         action->size    = recv_act->rcvd.act.buf_len;
         action->type    = recv_act->rcvd.act.type;
         action->seqno_g = recv_act->rcvd.id;

--- a/gcs/src/gcs_act_proto.cpp
+++ b/gcs/src/gcs_act_proto.cpp
@@ -82,7 +82,7 @@ gcs_act_proto_write (gcs_act_frag_t* frag, void* buf, size_t buf_len)
 long
 gcs_act_proto_read (gcs_act_frag_t* frag, const void* buf, size_t buf_len)
 {
-    frag->proto_ver = ((uint8_t*)buf)[PROTO_PV_OFFSET];
+    frag->proto_ver = ((const uint8_t*)buf)[PROTO_PV_OFFSET];
 
     if (gu_unlikely(buf_len < PROTO_DATA_OFFSET)) {
         gu_error ("Action message too short: %zu, expected at least %d",
@@ -96,13 +96,13 @@ gcs_act_proto_read (gcs_act_frag_t* frag, const void* buf, size_t buf_len)
         return -EPROTO; // this fragment should be dropped
     }
 
-    ((uint8_t*)buf)[PROTO_PV_OFFSET] = 0x0;
-    frag->act_id   = gu_be64(*(uint64_t*)buf);
-    frag->act_size = gtohl  (((uint32_t*)buf)[2]);
-    frag->frag_no  = gtohl  (((uint32_t*)buf)[3]);
+    (static_cast<uint8_t*>(const_cast<void*>(buf)))[PROTO_PV_OFFSET] = 0x0;
+    frag->act_id   = gu_be64(*(const uint64_t*)buf);
+    frag->act_size = gtohl  (((const uint32_t*)buf)[2]);
+    frag->frag_no  = gtohl  (((const uint32_t*)buf)[3]);
     frag->act_type = static_cast<gcs_act_type_t>(
-        ((uint8_t*)buf)[PROTO_AT_OFFSET]);
-    frag->frag     = ((uint8_t*)buf) + PROTO_DATA_OFFSET;
+        ((const uint8_t*)buf)[PROTO_AT_OFFSET]);
+    frag->frag     = ((const uint8_t*)buf) + PROTO_DATA_OFFSET;
     frag->frag_len = buf_len - PROTO_DATA_OFFSET;
 
     /* return 0 or -EMSGSIZE */

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -364,7 +364,7 @@ gcs_core_send (gcs_core_t*          const conn,
             act_size < frg.frag_len ? act_size : frg.frag_len;
 
         /* Here is the only time we have to cast frg.frag */
-        char* dst = (char*)frg.frag;
+        char* dst = static_cast<char*>(const_cast<void*>(frg.frag));
         size_t to_copy = chunk_size;
 
         while (to_copy > 0) {        // gather action bufs into one
@@ -416,7 +416,7 @@ gcs_core_send (gcs_core_t*          const conn,
 
                 /* 2. move ptr back to point at the first unsent byte */
                 size_t move_back = chunk_size - ret;
-                size_t ptrdiff   = ptr - (uint8_t*)action[idx].ptr;
+                size_t ptrdiff   = ptr - static_cast<const uint8_t*>(action[idx].ptr);
                 do {
                     if (move_back <= ptrdiff) {
                         ptr -= move_back;
@@ -428,7 +428,7 @@ gcs_core_send (gcs_core_t*          const conn,
                         move_back -= ptrdiff;
                         idx--;
                         ptrdiff = action[idx].size;
-                        ptr = (uint8_t*)action[idx].ptr + ptrdiff;
+                        ptr = static_cast<uint8_t*>(const_cast<void*>(action[idx].ptr)) + ptrdiff;
                     }
                 } while (true);
             }

--- a/gcs/src/gcs_defrag.cpp
+++ b/gcs/src/gcs_defrag.cpp
@@ -94,7 +94,7 @@ gcs_defrag_handle_frag (gcs_defrag_t*         df,
                 gu_error ("Unordered fragment received. Protocol error.");
                 gu_error ("Expected: %llu:%ld, received: %llu:%ld",
                           df->sent_id, df->frag_no, frg->act_id, frg->frag_no);
-                gu_error ("Contents: '%.*s'", frg->frag_len, (char*)frg->frag);
+                gu_error ("Contents: '%.*s'", frg->frag_len, (const char*)frg->frag);
                 df->frag_no--; // revert counter in hope that we get good frag
                 assert(0);
                 return -EPROTO;
@@ -127,12 +127,12 @@ gcs_defrag_handle_frag (gcs_defrag_t*         df,
                 return 0;
             }
             else {
-                ((char*)frg->frag)[frg->frag_len - 1] = '\0';
+                (static_cast<char*>(const_cast<void*>(frg->frag)))[frg->frag_len - 1] = '\0';
                 gu_error ("Unordered fragment received. Protocol error.");
                 gu_error ("Expected: any:0(first), received: %lld:%ld",
                           frg->act_id, frg->frag_no);
                 gu_error ("Contents: '%s', local: %s, reset: %s",
-                          (char*)frg->frag, local ? "yes" : "no",
+                          (const char*)frg->frag, local ? "yes" : "no",
                           df->reset ? "yes" : "no");
                 assert(0);
                 return -EPROTO;

--- a/gcs/src/gcs_dummy.cpp
+++ b/gcs/src/gcs_dummy.cpp
@@ -286,9 +286,9 @@ GCS_BACKEND_CREATE_FN(gcs_dummy_create)
         goto out0;
 
     dummy->state = DUMMY_CLOSED;
-    *(size_t*)(&dummy->max_pkt_size)  = (size_t) sysconf (_SC_PAGESIZE);
-    *(size_t*)(&dummy->hdr_size)      = sizeof(dummy_msg_t);
-    *(size_t*)(&dummy->max_send_size) = dummy->max_pkt_size - dummy->hdr_size;
+    *const_cast<size_t*>(&dummy->max_pkt_size)  = (size_t) sysconf (_SC_PAGESIZE);
+    *const_cast<size_t*>(&dummy->hdr_size)      = sizeof(dummy_msg_t);
+    *const_cast<size_t*>(&dummy->max_send_size) = dummy->max_pkt_size - dummy->hdr_size;
 
     if (!(dummy->gc_q = gu_fifo_create (1 << 16, sizeof(void*))))
         goto out1;

--- a/gcs/src/gcs_node.cpp
+++ b/gcs/src/gcs_node.cpp
@@ -45,11 +45,11 @@ gcs_node_init (gcs_node_t* const node,
 void
 gcs_node_move (gcs_node_t* dst, gcs_node_t* src)
 {
-    if (dst->name)      free ((char*)dst->name);
-    if (dst->inc_addr)  free ((char*)dst->inc_addr);
+    if (dst->name)      free (const_cast<char*>(dst->name));
+    if (dst->inc_addr)  free (const_cast<char*>(dst->inc_addr));
 
     if (dst->state_msg)
-        gcs_state_msg_destroy ((gcs_state_msg_t*)dst->state_msg);
+        gcs_state_msg_destroy (const_cast<gcs_state_msg_t*>(dst->state_msg));
 
     memcpy (dst, src, sizeof (gcs_node_t));
     gcs_defrag_forget (&src->app);
@@ -82,17 +82,17 @@ gcs_node_free (gcs_node_t* node)
     gcs_node_reset (node);
 
     if (node->name) {
-        free ((char*)node->name);     // was strdup'ed
+        free (const_cast<char*>(node->name));     // was strdup'ed
         node->name = NULL;
     }
 
     if (node->inc_addr) {
-        free ((char*)node->inc_addr); // was strdup'ed
+        free (const_cast<char*>(node->inc_addr)); // was strdup'ed
         node->inc_addr = NULL;
     }
 
     if (node->state_msg) {
-        gcs_state_msg_destroy ((gcs_state_msg_t*)node->state_msg);
+        gcs_state_msg_destroy (const_cast<gcs_state_msg_t*>(node->state_msg));
         node->state_msg = NULL;
     }
 }
@@ -102,7 +102,7 @@ void
 gcs_node_record_state (gcs_node_t* node, gcs_state_msg_t* state_msg)
 {
     if (node->state_msg) {
-        gcs_state_msg_destroy ((gcs_state_msg_t*)node->state_msg);
+        gcs_state_msg_destroy (const_cast<gcs_state_msg_t*>(node->state_msg));
     }
     node->state_msg = state_msg;
 
@@ -121,10 +121,10 @@ gcs_node_record_state (gcs_node_t* node, gcs_state_msg_t* state_msg)
                                  &node->repl_proto_ver,
                                  &node->appl_proto_ver);
 
-    if (node->name) free ((char*)node->name);
+    if (node->name) free (const_cast<char*>(node->name));
     node->name = strdup (gcs_state_msg_name (state_msg));
 
-    if (node->inc_addr) free ((char*)node->inc_addr);
+    if (node->inc_addr) free (const_cast<char*>(node->inc_addr));
     node->inc_addr = strdup (gcs_state_msg_inc_addr (state_msg));
 }
 
@@ -221,7 +221,7 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
             else {
                 node->desync_count = 1;
             }
-            // fall through
+            __attribute((fallthrough));
         case GCS_NODE_STATE_SYNCED:
             node->count_last_applied = true;
             break;
@@ -233,7 +233,7 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
             node->last_applied = 0;
             node->vote_seqno   = GCS_NO_VOTE_SEQNO;
             node->vote_res     = 0;
-            // fall through
+            __attribute((fallthrough));
         case GCS_NODE_STATE_JOINER:
             node->count_last_applied = false;
             break;

--- a/gcs/src/gcs_test.cpp
+++ b/gcs/src/gcs_test.cpp
@@ -525,7 +525,7 @@ void *gcs_test_recv (void *arg)
             //puts (thread->log_msg); fflush (stdout);
             break;
         case GCS_ACT_COMMIT_CUT:
-            group_seqno = *(gcs_seqno_t*)thread->act.buf;
+            group_seqno = *(const gcs_seqno_t*)thread->act.buf;
             gu_to_self_cancel (to, thread->act.seqno_l);
             break;
         case GCS_ACT_CCHANGE:
@@ -617,7 +617,7 @@ static long gcs_test_thread_pool_stop (const gcs_test_thread_pool_t *pool)
 long gcs_test_thread_pool_cancel (const gcs_test_thread_pool_t *pool)
 {
     long i;
-    printf ("Canceling pool: %p\n", (void*)pool); fflush(stdout);
+    printf ("Canceling pool: %p\n", (const void*)pool); fflush(stdout);
     printf ("pool type: %u, pool threads: %ld\n", pool->type, pool->n_started);
     fflush(stdout);
     for (i = 0; i < pool->n_started; i++) {
@@ -656,19 +656,19 @@ static long gcs_test_conf (gcs_test_conf_t *conf, long argc, char *argv[])
     case 6:
         conf->n_recv = strtol (argv[5], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        // fall through
+        __attribute__((fallthrough));
     case 5:
         conf->n_send = strtol (argv[4], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        // fall through
+        __attribute__((fallthrough));
     case 4:
         conf->n_repl = strtol (argv[3], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        // fall through
+        __attribute__((fallthrough));
     case 3:
         conf->n_tries = strtol (argv[2], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        // fall through
+        __attribute__((fallthrough));
     case 2:
         conf->backend = argv[1];
         break;

--- a/gcs/src/unit_tests/gcs_core_test.cpp
+++ b/gcs/src/unit_tests/gcs_core_test.cpp
@@ -148,7 +148,7 @@ core_recv_thread (void* arg)
     struct gcs_act_rcvd recv_act;
 
     act->size  = gcs_core_recv (Core, &recv_act, GU_TIME_ETERNITY);
-    act->out   = (void*)recv_act.act.buf;
+    act->out   = const_cast<void*>(recv_act.act.buf);
     act->local = recv_act.local;
     act->type  = recv_act.act.type;
     act->seqno = recv_act.id;
@@ -263,7 +263,7 @@ static bool CORE_RECV_ACT (action_t*      act,
     struct gcs_act_rcvd recv_act;
 
     act->size  = gcs_core_recv (Core, &recv_act, GU_TIME_ETERNITY);
-    act->out   = (void*)recv_act.act.buf;
+    act->out   = const_cast<void*>(recv_act.act.buf);
     act->local = recv_act.local;
     act->type  = recv_act.act.type;
     act->seqno = recv_act.id;

--- a/gcs/src/unit_tests/gcs_group_test.cpp
+++ b/gcs/src/unit_tests/gcs_group_test.cpp
@@ -36,7 +36,7 @@ msg_write (gcs_recv_msg_t* msg,
                   "Resulting frag_len %lu is less than required act_len %lu\n"
                   "Refactor the test and increase buf_len.",
                   frg->frag_len, data_len);
-    memcpy ((void*)frg->frag, data, data_len);
+    memcpy (const_cast<void*>(frg->frag), data, data_len);
 
     msg->buf        = buf;
     msg->buf_len    = buf_len;
@@ -209,7 +209,7 @@ START_TEST (gcs_group_configuration)
                   seqno, r_act.id);
     seqno++;
     // cleanup
-    free ((void*)act->buf);
+    free (const_cast<void*>(act->buf));
     r_act = gcs_act_rcvd();
 
     // 10. New component message
@@ -254,7 +254,7 @@ START_TEST (gcs_group_configuration)
                   seqno, r_act.id);
     seqno++;
     // cleanup
-    free ((void*)act->buf);
+    free (const_cast<void*>(act->buf));
     r_act = gcs_act_rcvd();
 
     // 12. Try foreign action with a new node joined in the middle.
@@ -300,7 +300,7 @@ START_TEST (gcs_group_configuration)
                   seqno, r_act.id);
     seqno++;
     // cleanup
-    free ((void*)act->buf);
+    free (const_cast<void*>(act->buf));
     r_act = gcs_act_rcvd();
 
     // 13. Try to send an action with one node disappearing in the middle
@@ -366,7 +366,7 @@ START_TEST (gcs_group_configuration)
     ck_assert_msg(r_act.id == -ERESTART, "Expected seqno %d, found %" PRId64,
                   -ERESTART, r_act.id);
     // cleanup
-    free ((void*)act->buf);
+    free (const_cast<void*>(act->buf));
     r_act = gcs_act_rcvd();
 
     // foreign message - action must be dropped (ignored)
@@ -386,7 +386,7 @@ START_TEST (gcs_group_configuration)
                   GCS_SEQNO_ILL, r_act.id);
     ck_assert(group.act_id_ + 1 == seqno);
     // cleanup
-    free ((void*)act->buf);
+    free (const_cast<void*>(act->buf));
     r_act = gcs_act_rcvd();
 
     // Leave group

--- a/gcs/src/unit_tests/gcs_proto_test.cpp
+++ b/gcs/src/unit_tests/gcs_proto_test.cpp
@@ -51,7 +51,7 @@ START_TEST (gcs_proto_test)
                   " - increase send action length");
 
     // write action to the buffer, it should not fit
-    strncpy ((char*)frg_send.frag, act_send_ptr, frg_send.frag_len);
+    strncpy (static_cast<char*>(const_cast<void*>(frg_send.frag)), act_send_ptr, frg_send.frag_len);
     act_send_ptr += frg_send.frag_len;
 
     // message was sent and received, now parse the header
@@ -75,7 +75,7 @@ START_TEST (gcs_proto_test)
     gcs_act_proto_inc (buf); // should be 1 now
 
     // write action to the buffer, it should fit now
-    strncpy ((char*)frg_send.frag, act_send_ptr, frg_send.frag_len);
+    strncpy (static_cast<char*>(const_cast<void*>(frg_send.frag)), act_send_ptr, frg_send.frag_len);
     //    act_send_ptr += frg_send.frag_len;
 
     // message was sent and received, now parse the header

--- a/gcs/src/unit_tests/gcs_state_msg_test.cpp
+++ b/gcs/src/unit_tests/gcs_state_msg_test.cpp
@@ -237,7 +237,7 @@ START_TEST (gcs_state_msg_test_quorum_inherit)
     ck_assert(NULL != st[2]);
 
     gu_info ("                  Inherited 1");
-    int ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    int ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                         sizeof(st)/sizeof(gcs_state_msg_t*),
                                         &quorum);
     ck_assert(0 == ret);
@@ -263,7 +263,7 @@ START_TEST (gcs_state_msg_test_quorum_inherit)
     ck_assert(NULL != st[1]);
 
     gu_info ("                  Inherited 2");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -289,7 +289,7 @@ START_TEST (gcs_state_msg_test_quorum_inherit)
     ck_assert(NULL != st[0]);
 
     gu_info ("                  Inherited 3");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -315,7 +315,7 @@ START_TEST (gcs_state_msg_test_quorum_inherit)
     ck_assert(NULL != st[1]);
 
     gu_info ("                  Inherited 4");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -341,7 +341,7 @@ START_TEST (gcs_state_msg_test_quorum_inherit)
     ck_assert(NULL != st[2]);
 
     gu_info ("                  Inherited 5");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -417,7 +417,7 @@ START_TEST (gcs_state_msg_test_quorum_remerge)
     ck_assert(NULL != st[2]);
 
     gu_info ("                  Remerged 1");
-    int ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    int ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                         sizeof(st)/sizeof(gcs_state_msg_t*),
                                         &quorum);
     ck_assert(0 == ret);
@@ -444,7 +444,7 @@ START_TEST (gcs_state_msg_test_quorum_remerge)
     ck_assert(3 == gcs_state_msg_get_desync_count(st[0]));
 
     gu_info ("                  Remerged 2");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -470,7 +470,7 @@ START_TEST (gcs_state_msg_test_quorum_remerge)
     ck_assert(NULL != st[2]);
 
     gu_info ("                  Remerged 3");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -496,7 +496,7 @@ START_TEST (gcs_state_msg_test_quorum_remerge)
     ck_assert(NULL != st[1]);
 
     gu_info ("                  Remerged 4");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -522,7 +522,7 @@ START_TEST (gcs_state_msg_test_quorum_remerge)
     ck_assert(NULL != st[1]);
 
     gu_info ("                  Remerged 5");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -636,7 +636,7 @@ void gcs_state_msg_test_gh24(int const gcs_proto_ver)
                                  gcs_proto_ver, 4, 2, 0, 0, 0,
                                  0, 2);
     ck_assert(st[6] != 0);
-    int ret = gcs_state_msg_get_quorum((const gcs_state_msg_t**)st, 7,
+    int ret = gcs_state_msg_get_quorum(const_cast<const gcs_state_msg_t**>(st), 7,
                                        &quorum);
     ck_assert(ret == 0);
     ck_assert(quorum.primary == true);
@@ -727,7 +727,7 @@ gcs_state_msg_test_v6_upgrade(int const from_ver)
 
     gu_info ("                  proto_ver I");
     int
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     sizeof(st)/sizeof(gcs_state_msg_t*),
                                     &quorum);
     ck_assert(0 == ret);
@@ -754,7 +754,7 @@ gcs_state_msg_test_v6_upgrade(int const from_ver)
     UPDATE_STATE_MSG(0);
     UPDATE_STATE_MSG(1);
     gu_info ("                  proto_ver II");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     2,
                                     &quorum);
     ck_assert(0 == ret);
@@ -775,7 +775,7 @@ gcs_state_msg_test_v6_upgrade(int const from_ver)
     UPDATE_STATE_MSG(0);
     UPDATE_STATE_MSG(1);
     gu_info ("                  proto_ver III");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     3,
                                     &quorum);
     ck_assert(0 == ret);
@@ -796,7 +796,7 @@ gcs_state_msg_test_v6_upgrade(int const from_ver)
     UPDATE_STATE_MSG(0);
     UPDATE_STATE_MSG(1);
     gu_info ("                  proto_ver IV");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     2,
                                     &quorum);
     ck_assert(0 == ret);
@@ -822,7 +822,7 @@ gcs_state_msg_test_v6_upgrade(int const from_ver)
     UPDATE_STATE_MSG(0);
     UPDATE_STATE_MSG(1);
     gu_info ("                  proto_ver V");
-    ret = gcs_state_msg_get_quorum ((const gcs_state_msg_t**)st,
+    ret = gcs_state_msg_get_quorum (const_cast<const gcs_state_msg_t**>(st),
                                     3,
                                     &quorum);
     ck_assert(0 == ret);

--- a/gcs/src/unit_tests/gcs_test_utils.cpp
+++ b/gcs/src/unit_tests/gcs_test_utils.cpp
@@ -452,7 +452,7 @@ gt_group::sst_start (int const joiner_idx,const char* donor_name)
         int ret = gcs_group_handle_state_request(nodes[i]->group(), &req);
 
         if (ret < 0) { // don't fail here, we may want to test negatives
-            gu_error (ret < 0, "Handling state request to '%s' failed: %d (%s)",
+            gu_error ("Handling state request to '%s' failed: %d (%s)",
                       donor_name, ret, strerror (-ret));
             return ret;
         }


### PR DESCRIPTION
This commit modifies the galera source so it builds correctly as a
subproject of PXC, with MYSQL_MAINTAINER_MODE=ON

Source changes:
 * Changed fallthrough hints
 * Added __attribute__((format)) where required
 * Changed the signature of gu_log to support the format attribute
 * Fixed incorrect format strings detected by the above
 * Disabled variable hint array warnings
 * Modified some C-style casts to keep constness where possible
 * Modified them to const/reinterpret cast otherwise
 * Unnecessary ; are removed
 * Unnecessary GNU macros (e.g. _GNU_SOURCE) removed
 * EAGAIN and EWOULDBLOCK is the same, only kept one with a static
   assert
 * Corrected some #if to #ifdef
 * Galerautils tests are built without -Wformat because of use of
   deprecated check functions
 * GCS_FOR_GARB definition should be public for gcs4garb target