### PR TITLE
PXC-4020: Galera unit tests execution fails

### DIFF
--- a/galera/tests/certification_check.cpp
+++ b/galera/tests/certification_check.cpp
@@ -215,10 +215,12 @@ START_TEST(test_certification_trx_v3)
           { {void_cast("1"), 1}, {void_cast("1"), 1}, {void_cast("1"), 1} }, 3, true,
           9, 9, 0, 5, TrxHandle::F_BEGIN | TrxHandle::F_COMMIT,
           Certification::TEST_OK, {0}, 0},
-        // 10: depends on 5
+        // 10: depends on 5 if optimistic_pa=yes
+        // for PXC, by defult optimistic_pa=no, so
+        // 10: depends on 6
         { { {2, } }, 1, 10,
           { {void_cast("1"), 1}, {void_cast("1"), 1}, {void_cast("1"), 1} }, 3, true,
-          10, 10, 6, 5, TrxHandle::F_BEGIN | TrxHandle::F_COMMIT,
+          10, 10, 6, 6, TrxHandle::F_BEGIN | TrxHandle::F_COMMIT,
           Certification::TEST_OK, {0}, 0},
         // 11 - 13: exclusive - shared - exclusive dependency
         { { {2, } }, 1, 11,

--- a/gcomm/test/check_evs2.cpp
+++ b/gcomm/test/check_evs2.cpp
@@ -2513,7 +2513,8 @@ START_TEST(test_out_queue_limit)
                            new gu::Buffer(data.begin(), data.end())));
     // Default user send window is 2 and out queue limit is 1M,
     // so we can write 2 + 32 messages without blocking.
-    for (size_t i(0); i < 34; ++i)
+    // For PXC evs.user_send_window is 4, hence 4 + 32
+    for (size_t i(0); i < 36; ++i)
     {
         ck_assert(f.evs1.handle_down(dg, ProtoDownMeta(O_SAFE)) == 0);
     }

--- a/wsrep/tests/SConscript
+++ b/wsrep/tests/SConscript
@@ -10,9 +10,11 @@
 
 Import('check_env', 'GALERA_VER', 'GALERA_REV')
 
+# Galera reports whatever is specified in version build parameter, like 'scons version=my_version',
+# so the test should validate against the same.
 # make sure API version is present once in GALERA_VER string
-API = '26.'
-GALERA_VER = API + GALERA_VER.replace(API, '')
+# API = '26.'
+# GALERA_VER = API + GALERA_VER.replace(API, '')
 
 # Clone environment as we need to tune compilation flags
 env = check_env.Clone()

--- a/wsrep/tests/wsrep_loader_test.c
+++ b/wsrep/tests/wsrep_loader_test.c
@@ -43,7 +43,7 @@ int wsrep_load_unload()
         abort();
     }
     snprintf(expected_version, sizeof(expected_version) - 1,
-             "%s(r%s)", GALERA_VERSION, GALERA_GIT_REVISION);
+             "%s(%s)", GALERA_VERSION, GALERA_GIT_REVISION);
     if (strcmp(wsrep->provider_version, expected_version))
     {
         fprintf(stderr, "Provider version string '%s' not expected '%s'\n",


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4020

Fixed Galera unit tests:
test_out_queue_limit - test failed because evs.user_send_window defaults to 4 in PXC instead of upstream's 2

test_certification_trx_v3 - test failed because cert.optimistic_pa defaults to 'no' in PXC instead of upstream's 'yes'

wsrep_loader test failed because of wrong calculation of GALERA_VERSION pased during compilation of the test. This test also fails in upstream version.