### PR TITLE
PXC-3998: OpenSSL 3 adjustments

### DIFF
--- a/asio/asio/ssl/context_base.hpp
+++ b/asio/asio/ssl/context_base.hpp
@@ -113,6 +113,10 @@ public:
 
   /// Disable compression. Compression is disabled by default.
   static const long no_compression = implementation_defined;
+
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  static const long ignore_unexpected_eof = implementation_defined;
+#endif // (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 #else
   ASIO_STATIC_CONSTANT(long, default_workarounds = SSL_OP_ALL);
   ASIO_STATIC_CONSTANT(long, single_dh_use = SSL_OP_SINGLE_DH_USE);
@@ -135,7 +139,9 @@ public:
   ASIO_STATIC_CONSTANT(long, no_compression = 0x20000L);
 # endif // defined(SSL_OP_NO_COMPRESSION)
 #endif
-
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  ASIO_STATIC_CONSTANT(long, ignore_unexpected_eof = SSL_OP_IGNORE_UNEXPECTED_EOF);
+#endif // (OPENSSL_VERSION_NUMBER >= 0x30000000L)
   /// File format types.
   enum file_format
   {

--- a/asio/asio/ssl/impl/context.ipp
+++ b/asio/asio/ssl/impl/context.ipp
@@ -197,6 +197,10 @@ context::context(context::method m)
   }
 
   set_options(no_compression);
+
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  set_options(ignore_unexpected_eof);
+#endif // (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 }
 
 context::context(asio::io_service&, context::method m)

--- a/galerautils/src/gu_asio_stream_engine.cpp
+++ b/galerautils/src/gu_asio_stream_engine.cpp
@@ -294,6 +294,10 @@ private:
             last_verify_error_ = SSL_get_verify_result(ssl_);
             return error;
         }
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+        case SSL_ERROR_ZERO_RETURN:
+            return eof;
+#endif // (OPENSSL_VERSION_NUMBER >= 0x30000000L)
         }
         assert(0);
         return error;


### PR DESCRIPTION
With OpenSSL 3 when SSL connection is terminated by peer, the library issues the error
'error:0A000126:SSL routines::unexpected eof while reading' which causes the following MTR tests to fail:

galera.pxc_encrypt_rest_redo
galera.pxc_encrypt_rest_fpt
galera.pxc_encrypt_rest_gt
galera.pxc_encrypt_rest_system
galera.pxc_encrypt_rest_mkey_rotate
galera.pxc_encrypt_rest_blog
galera.pxc_encrypt_rest_parallel_dblwr
galera.pxc_encrypt_rest_tt
galera.pxc_encrypt_rest_undo

It is related to fixing bug discussed in
https://github.com/openssl/openssl/issues/18866
and introducing SSL_OP_IGNORE_UNEXPECTED_EOF flag.

SSL_OP_IGNORE_UNEXPECTED_EOF has been set for OpenSSL 3 and the error handled gracefuly.