### PR TITLE
PXC-3991: Coredumper support for garbd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(GALERA_VERSION_SCRIPT "Limit symbols visible from Galera DSO" ON)
 option(GALERA_STATIC "Build statically linked binaries" OFF)
 option(GALERA_SOURCE
   "Configure for source package only, skipping build configuration" OFF)
+option(WITH_COREDUMPER "Build garbd with coredumper" ON)
 
 # Developer options and instrumentation.
 option(GALERA_WITH_ASAN "Enable ASAN instrumentation" OFF)

--- a/garb/CMakeLists.txt
+++ b/garb/CMakeLists.txt
@@ -46,3 +46,12 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
     ${PROJECT_SOURCE_DIR}/man/garbd.8
     DESTINATION man/man8)
 endif()
+
+if(WITH_COREDUMPER)
+  target_link_libraries( garbd coredumper )
+  target_compile_definitions(garbd
+    PRIVATE
+    -DWITH_COREDUMPER=1
+  )
+
+endif()

--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -46,6 +46,9 @@ Config::Config (int argc, char* argv[])
       cfg_     (),
       recv_script_ (),
       workdir_ (),
+#if defined(WITH_COREDUMPER) && WITH_COREDUMPER
+      coredumper_ (),
+#endif
       exit_    (false)
 {
     po::options_description other ("Other options");
@@ -58,6 +61,9 @@ Config::Config (int argc, char* argv[])
     po::options_description config ("Configuration");
     config.add_options()
         ("daemon,d", "Become daemon")
+#if defined(WITH_COREDUMPER) && WITH_COREDUMPER
+        ("coredumper", po::value<std::string>(&coredumper_), "Path to dump core file on crash")
+#endif
         ("name,n",      po::value<std::string>(&name_),        "Node name")
         ("address,a",   po::value<std::string>(&address_),     "Group address")
         ("group,g",     po::value<std::string>(&group_),       "Group name")

--- a/garb/garb_config.hpp
+++ b/garb/garb_config.hpp
@@ -28,6 +28,9 @@ public:
     const std::string& cfg()     const { return cfg_    ; }
     const std::string& log()     const { return log_    ; }
     const std::string& workdir() const { return workdir_; }
+#if defined(WITH_COREDUMPER) && WITH_COREDUMPER
+    const std::string& coredumper() const { return coredumper_; }
+#endif
     bool               exit()    const { return exit_   ; }
     const std::string& recv_script() const { return recv_script_    ; }
 
@@ -44,6 +47,9 @@ private:
     std::string cfg_;
     std::string recv_script_;
     std::string workdir_;
+#if defined(WITH_COREDUMPER) && WITH_COREDUMPER
+    std::string coredumper_;
+#endif
     bool exit_; /* Exit on --help or --version */
 
 }; /* class Config */

--- a/garb/garb_main.cpp
+++ b/garb/garb_main.cpp
@@ -13,6 +13,71 @@
 #include <thread>
 #include <chrono>
 
+#if defined(WITH_COREDUMPER) && WITH_COREDUMPER
+#include "coredumper/coredumper.h"
+
+#include <signal.h>
+
+void my_write_libcoredumper(int sig, const char *path, time_t curr_time) {
+  int ret = 0;
+  char suffix[512];
+  char core[512];
+  struct tm *timeinfo = gmtime(&curr_time);
+  if (path == NULL)
+    strcpy(core, "core");
+  else
+    strcpy(core, path);
+  sprintf(suffix, ".%d%02d%02d%02d%02d%02d", (1900 + timeinfo->tm_year),
+      timeinfo->tm_mon, timeinfo->tm_mday, timeinfo->tm_hour,
+      timeinfo->tm_min, timeinfo->tm_sec);
+  strcat(core, suffix);
+  fprintf(stderr, "CORE PATH: %s\n\n", core);
+  ret = WriteCoreDump(core);
+  if (ret != 0) {
+    fprintf(stderr, "Error writting coredump: %d Signal: %d\n", ret, sig);
+  }
+}
+
+std::string coredumper_core_path;
+
+extern "C" void handle_fatal_signal(int sig) {
+  my_write_libcoredumper(sig, coredumper_core_path.c_str(), time(nullptr));
+  _exit(1);  // Using _exit(), since exit() is not async
+             // signal safe
+}
+
+extern "C" {
+  static void empty_signal_handler(int sig [[maybe_unused]]) {
+  }
+
+  void set_coredumper_signals(std::string const& core_path) {
+    coredumper_core_path = core_path;
+
+    // init signal handler to use coredumper
+    struct sigaction sa;
+    (void)sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND | SA_NODEFER;
+    sa.sa_handler = handle_fatal_signal;
+    // Treat these as fatal and handle them.
+    sigaction(SIGABRT, &sa, nullptr);
+    sigaction(SIGFPE, &sa, nullptr);
+    sigaction(SIGBUS, &sa, nullptr);
+    sigaction(SIGILL, &sa, nullptr);
+    sigaction(SIGSEGV, &sa, nullptr);
+    sa.sa_handler = empty_signal_handler;
+    (void)sigaction(SIGALRM, &sa, nullptr);
+    sa.sa_handler = SIG_DFL;
+    (void)sigaction(SIGTERM, &sa, nullptr);
+    (void)sigaction(SIGHUP, &sa, nullptr);
+    (void)sigaction(SIGUSR1, &sa, nullptr);
+    // Ignore SIGPIPE
+    sa.sa_flags = 0;
+    sa.sa_handler = SIG_IGN;
+    (void)sigaction(SIGPIPE, &sa, nullptr);
+  }
+}
+#endif
+
 namespace garb
 {
 
@@ -94,6 +159,11 @@ int
 main (int argc, char* argv[])
 {
     Config config(argc, argv);
+#if defined(WITH_COREDUMPER) && WITH_COREDUMPER
+    if(!config.coredumper().empty()) {
+      set_coredumper_signals(config.coredumper());
+    }
+#endif
     if (config.exit()) return 0;
 
     log_info << "Read config: " <<  config << std::endl;


### PR DESCRIPTION
This commit adds a new "--coredumper=<path>" option to garbd. When this option is used, and garbd crashes, a coredump will be written to the given path, with a ".<timestamp" added to it.

The option is only compiled when the WITH_COREDUMPER definition is set, and its value is 1.

Currently this is only added to the CMake based build, which is used as a sub-project of the main CMake build, and has the required libcoredumper dependency set up.