### PR TITLE
PXC-3936: state transfer with SSL disabled in wsrep_provider_options …

### DIFF
--- a/galera/src/ist.cpp
+++ b/galera/src/ist.cpp
@@ -197,13 +197,12 @@ static void IST_fix_addr_scheme(const gu::Config& conf, std::string& addr)
 #ifdef GALERA_HAVE_SSL
         try
         {
-            std::string ssl_key = conf.get(gu::conf::ssl_key);
-            bool dynamic_socket = false;
-            if (conf.has(gu::conf::socket_dynamic))
-            {
-                dynamic_socket = conf.get<bool>(gu::conf::socket_dynamic, false);
-            }
-            if (ssl_key.length() != 0 && not dynamic_socket)
+            using namespace gu;
+            bool use_ssl = conf.has(conf::use_ssl) ? conf.get<bool>(conf::use_ssl, true) : true;
+            std::string ssl_key = conf.get(conf::ssl_key);
+            bool dynamic_socket = conf.has(conf::socket_dynamic) && conf.get<bool>(conf::socket_dynamic, false);
+
+            if (use_ssl && ssl_key.length() != 0 && not dynamic_socket)
             {
                 addr.insert(0, "ssl://");
                 return;


### PR DESCRIPTION
…crashes Receiver and Donor node

https://jira.percona.com/browse/PXC-3936

Problem:
When setting socket.ssl = NO in wsrep_provider_options without explicitly specifying if SSL is used in the [SST] part of my.cnf, not only will the state transfer fail, but it will crash the donor node as well as the receiver node.

Cause:
IST_fix_addr_scheme only relies on socket.ssl_key config property and doesn't take into account socket.ssl (use_ssl in code).

Solution:
Take socket.ssl into account in IST_fix_addr_scheme.