### PR TITLE
PXC-4050: 8.0.31 merge (post merge commit, centos7 compilation fix)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -351,6 +351,8 @@ int main()
     return 0;
 }
 
+#error Forcing bundled ASIO to be used always!
+
 """
     context.Message('Checking ASIO version (>= 1.10.8 and < 1.11.0) ... ')
     result = context.TryLink(system_asio_test_source_file, '.cpp')


### PR DESCRIPTION
Problem:
centos:7 compilation fails, becaus compiler complains about the lack of basic_socket::async_wait() method (and others).

Cause:
centos:7 default asio is 1.10.8.
Scons configuration script switches to system asio if its 101008 < version <= 101100.

Problematic method was added in asio lib commit
b60e92b13ef68dfbb9af180d76eae41d22e19356 which is

git tag --contains b60e92b13ef68dfbb9af180d76eae41d22e19356 boost-1.66.0

which has asio 1.12.0

So there is no this method in system asio lib.

Usage of problematic method was introduced in
Galera commit 9a9ef8fa65c41654578a69256abbf735dd7de562 (part of release_26.4.13)

Solution:
Force bundled asio always.


Note: Cmake build is not affected, but it gives a version threashold at 1.22.1. As we built with bundled asio mostly so far, let's continue this for 8.0.31. We will switch to cmake on 8.0.32