### PR TITLE
PXC-4158: Fix compilation issues with clang-6 up to clang-12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ endif()
 # Suppress warnings for all clang versions
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   remove_compile_flags(-Wdeprecated -Wdeprecated-dynamic-exception-spec -Winconsistent-missing-destructor-override -Wshadow-field -Wheader-hygiene)
+  # fix clang-12 issue: galerautils/src/gu_deqmap.hpp:505:20: error: returning address of local temporary object [-Werror,-Wreturn-stack-address]
+  IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+    append_cflags_if_supported(-Wno-return-stack-address)
+  ENDIF()
 ENDIF()
 
 add_subdirectory(galerautils)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -80,3 +80,22 @@ MACRO (remove_compile_flags)
     ENDIF(CMAKE_CXX_FLAGS MATCHES ${flag})
   ENDFOREACH (flag)
 ENDMACRO (remove_compile_flags)
+
+
+#
+# Append flags CMAKE_C_FLAGS to CMAKE_CXX_FLAGS if supported by compiler
+# usage: append_cflags_if_supported(-Wno-return-stack-address)
+#
+MACRO (append_cflags_if_supported)
+  FOREACH (flag ${ARGN})
+    STRING (REGEX REPLACE "-" "_" temp_flag ${flag})
+    check_c_compiler_flag (${flag} HAVE_C_${temp_flag})
+    IF (HAVE_C_${temp_flag})
+      SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}")
+    ENDIF ()
+    check_cxx_compiler_flag (${flag} HAVE_CXX_${temp_flag})
+    IF (HAVE_CXX_${temp_flag})
+      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+    ENDIF ()
+  ENDFOREACH (flag)
+ENDMACRO (append_cflags_if_supported)

--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -186,10 +186,10 @@ check_against(const galera::KeyEntryNG*   const found,
                          << " for key " << key << ": "
                          << *trx << " <---> " << *ref_trx;
             }
-            __attribute__((fallthrough));
+            [[fallthrough]];
         case DEPENDENCY:
             depends_seqno = std::max(ref_trx->global_seqno(), depends_seqno);
-            __attribute__((fallthrough));
+            [[fallthrough]];
         case NOTHING:;
         }
     }

--- a/galera/src/ist_proto.hpp
+++ b/galera/src/ist_proto.hpp
@@ -711,7 +711,7 @@ namespace galera
                     case Message::T_CCHANGE:
                         act.buf  = wbuf;           // not skip
                         act.size = wsize;
-                        __attribute((fallthrough));
+                        [[fallthrough]];
                     case Message::T_SKIP:
                         act.seqno_g = msg.seqno(); // not EOF
                         act.type    = gcs_type;

--- a/galera/src/key_os.hpp
+++ b/galera/src/key_os.hpp
@@ -235,7 +235,7 @@ namespace galera
         {
         case 2:
             os << std::hex << static_cast<int>(key.flags()) << " ";
-            __attribute((fallthrough));
+            [[fallthrough]];
         case 1:
         {
             std::deque<KeyPartOS> dq(key.key_parts<std::deque<KeyPartOS> >());

--- a/galera/src/key_set.hpp
+++ b/galera/src/key_set.hpp
@@ -231,7 +231,7 @@ public:
 #else
                 ret = (lhs[2] == rhs[2] && lhs[3] == rhs[3]);
 #endif /* WORDSIZE */
-                __attribute((fallthrough));
+                [[fallthrough]];
             case FLAT8:
             case FLAT8A:
                 /* shift is to clear up the header */

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -357,7 +357,7 @@ galera::ReplicatorSMM::~ReplicatorSMM()
     case S_DONOR:
         start_closing();
         wait_for_CLOSED(lock);
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case S_CLOSED:
         ist_senders_.cancel();
         break;
@@ -1038,7 +1038,7 @@ galera::ReplicatorSMM::abort_trx(TrxHandleMaster& trx, wsrep_seqno_t bf_seqno,
     case TrxHandle::S_ROLLING_BACK:
         log_error << "Attempt to enter commit monitor while holding "
             "locks in rollback by " << trx;
-        __attribute__((fallthrough));
+        [[fallthrough]];
     default:
         log_warn << "invalid state " << trx.state()
                  << " in abort_trx for trx"
@@ -1169,7 +1169,7 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandleMaster& trx,
             assert(ts.is_dummy());
             break;
         }
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case TrxHandle::S_CERTIFYING:
     {
         assert(ts.state() == TrxHandle::S_CERTIFYING);
@@ -1178,7 +1178,7 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandleMaster& trx,
         assert(apply_monitor_.entered(ao) == false);
         gu_trace(apply_monitor_.enter(ao));
         TX_SET_STATE(ts, TrxHandle::S_APPLYING);
-        __attribute__((fallthrough));
+        [[fallthrough]];
     }
     case TrxHandle::S_APPLYING:
         //
@@ -3767,7 +3767,7 @@ void galera::ReplicatorSMM::enter_apply_monitor_for_local_not_committing(
     {
     case TrxHandle::S_REPLICATING:
         TX_SET_STATE(ts, TrxHandle::S_CERTIFYING);
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case TrxHandle::S_CERTIFYING:
     {
         ApplyOrder ao(ts);

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -808,7 +808,7 @@ namespace galera
                     return is_local_;
 #endif /* PXC */
                     // in case of remote trx fall through
-                    __attribute__((fallthrough));
+                    [[fallthrough]];
                 case NO_OOOC:
                     return (last_left + 1 == global_seqno_);
                 }

--- a/galerautils/src/gu_asio_stream_react.cpp
+++ b/galerautils/src/gu_asio_stream_react.cpp
@@ -419,7 +419,7 @@ void gu::AsioStreamReact::complete_server_handshake(
         break;
     case AsioStreamEngine::error:
         log_warn << "Handshake failed: " << engine_->last_error();
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case AsioStreamEngine::eof:
         // Restart accepting transparently. The socket will go out of
         // scope and will be destructed.

--- a/galerautils/src/gu_rset.cpp
+++ b/galerautils/src/gu_rset.cpp
@@ -254,7 +254,7 @@ RecordSetOutBase::write_header (byte_t* const buf, ssize_t const size)
             ::memset(buf + off + 4, 0, hdr_size - 8);
         }
         buf[off+4] = 0;
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case VER1:
         buf[off] = ver_byte; off += 1;
         off += uleb128_encode(size_, buf + off, size - off);

--- a/gcomm/src/evs_proto.cpp
+++ b/gcomm/src/evs_proto.cpp
@@ -2689,7 +2689,7 @@ int gcomm::evs::Proto::handle_down(Datagram& wb, const ProtoDownMeta& dm)
         {
         case EAGAIN:
             output_.push_back(std::make_pair(wb, dm));
-            __attribute__((fallthrough));
+            [[fallthrough]];
         case 0:
             ret = 0;
             break;

--- a/gcs/src/gcs_node.cpp
+++ b/gcs/src/gcs_node.cpp
@@ -221,7 +221,7 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
             else {
                 node->desync_count = 1;
             }
-            __attribute((fallthrough));
+            [[fallthrough]];
         case GCS_NODE_STATE_SYNCED:
             node->count_last_applied = true;
             break;
@@ -233,7 +233,7 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
             node->last_applied = 0;
             node->vote_seqno   = GCS_NO_VOTE_SEQNO;
             node->vote_res     = 0;
-            __attribute((fallthrough));
+            [[fallthrough]];
         case GCS_NODE_STATE_JOINER:
             node->count_last_applied = false;
             break;

--- a/gcs/src/gcs_test.cpp
+++ b/gcs/src/gcs_test.cpp
@@ -656,19 +656,19 @@ static long gcs_test_conf (gcs_test_conf_t *conf, long argc, char *argv[])
     case 6:
         conf->n_recv = strtol (argv[5], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case 5:
         conf->n_send = strtol (argv[4], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case 4:
         conf->n_repl = strtol (argv[3], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case 3:
         conf->n_tries = strtol (argv[2], &endptr, 10);
         if ('\0' != *endptr) goto error;
-        __attribute__((fallthrough));
+        [[fallthrough]];
     case 2:
         conf->backend = argv[1];
         break;


### PR DESCRIPTION
1. Fix clang-12 issue: galerautils/src/gu_deqmap.hpp:505:20: error: returning address of local temporary object [-Werror,-Wreturn-stack-address]
2. Fix clang-6 to clang-9 issue: galerautils/src/gu_rset.cpp:257:9: error: declaration does not declare anything [-Werror,-Wmissing-declarations] __attribute__((fallthrough));