### PR TITLE
PXC-3760: Implement a feature to evict a lagging node from PXC

### DIFF
--- a/galera/tests/defaults_check.cpp
+++ b/galera/tests/defaults_check.cpp
@@ -73,6 +73,8 @@ static const char* Defaults[] =
     "gcache.encryption_cache_size", "16777216",
     "gcomm.thread_prio",           "",
     "gcs.fc_debug",                "0",
+    "gcs.fc_auto_evict_window",    "0",
+    "gcs.fc_auto_evict_threshold", "0.75",
     "gcs.fc_factor",               "1.0",
     "gcs.fc_limit",                "100",
     "gcs.fc_master_slave",         "no",

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -28,6 +28,7 @@
 #include <math.h>
 #include <errno.h>
 #include <assert.h>
+#include <atomic>
 
 #ifdef PXC
 #include "gu_debug_sync.hpp"
@@ -192,6 +193,8 @@ struct gcs_conn
     long         upper_limit;         // upper slave queue limit
     long         lower_limit;         // lower slave queue limit
     long         fc_offset;           // offset for catchup phase
+    std::atomic_llong fc_auto_evict_window_ns;
+    std::atomic_llong fc_auto_evict_threshold_ns;
     /*
       Maximum state when FC is enabled.
 
@@ -325,6 +328,17 @@ enomem:
     return rc;
 }
 
+static void
+update_fc_auto_evict_params(gcs_conn_t* conn, bool update_window = true)
+{
+    if (update_window) {
+        conn->fc_auto_evict_window_ns =
+            conn->params.fc_auto_evict_window * 1000000000LL;
+    }
+    conn->fc_auto_evict_threshold_ns =
+        conn->fc_auto_evict_window_ns * conn->params.fc_auto_evict_threshold;
+}
+
 /* Creates a group connection handle */
 gcs_conn_t*
 gcs_create (gu_config_t* const conf, gcache_t* const gcache,
@@ -392,7 +406,7 @@ gcs_create (gu_config_t* const conf, gcache_t* const gcache,
         goto recv_q_failed;
     }
 
-    conn->sm = gcs_sm_create(1<<16, 1);
+    conn->sm = gcs_sm_create(1<<16, 1, conn->params.fc_auto_evict_window > 0);
 
     if (!conn->sm) {
         gu_error ("Failed to create send monitor");
@@ -410,6 +424,7 @@ gcs_create (gu_config_t* const conf, gcache_t* const gcache,
     conn->gcache       = gcache;
     conn->max_fc_state = conn->params.sync_donor ?
         GCS_CONN_DONOR : GCS_CONN_JOINED;
+    update_fc_auto_evict_params(conn);
 
     gu_mutex_init (&conn->fc_lock, NULL);
     gu_mutex_init (&conn->vote_lock_, NULL);
@@ -994,6 +1009,13 @@ _set_fc_limits (gcs_conn_t* conn)
              conn->lower_limit, conn->upper_limit);
 }
 
+static long
+#ifdef GCS_FOR_GARB
+_close(gcs_conn_t* conn, bool join_recv_thread, bool explicit_close = false);
+#else
+_close(gcs_conn_t* conn, bool join_recv_thread);
+#endif
+
 /*! Handles flow control events
  *  (this is frequent, so leave it inlined) */
 static inline void
@@ -1013,6 +1035,23 @@ gcs_handle_flow_control (gcs_conn_t*                conn,
     }
     else if (0 == conn->stop_count) {
         gcs_sm_continue (conn->sm); // last CONT request
+    }
+
+    if (conn->params.fc_auto_evict_window > 0) {
+        const long long paused =
+            gcs_sm_paused_in_window_get(conn->sm, conn->fc_auto_evict_window_ns,
+                                        !(conn->local_act_id % 10)); // erase not very often
+        gu_debug ("FC auto evict: paused for %lld ns.", paused);
+
+        if (paused >= conn->fc_auto_evict_threshold_ns) {
+            gu_info ("Triggering automatic eviction of the node since flow control pause limit "
+                     "exceeded (%f from %f in %f sec window). The node will be aborted.",
+                     paused * 1.0e-9, conn->fc_auto_evict_threshold_ns * 1.0e-9,
+                     conn->fc_auto_evict_window_ns * 1.0e-9);
+            gcs_shift_state (conn, GCS_CONN_CLOSED);
+            _close(conn, false);
+            gu_abort();
+        }
     }
 
     return;
@@ -1472,7 +1511,7 @@ _check_recv_queue_growth (gcs_conn_t* conn, ssize_t size)
 
 static long
 #ifdef GCS_FOR_GARB
-_close(gcs_conn_t* conn, bool join_recv_thread, bool explicit_close = false)
+_close(gcs_conn_t* conn, bool join_recv_thread, bool explicit_close)
 #else
 _close(gcs_conn_t* conn, bool join_recv_thread)
 #endif
@@ -2703,6 +2742,47 @@ _set_fc_debug (gcs_conn_t* conn, const char* value)
 }
 
 static long
+_set_fc_auto_evict_window (gcs_conn_t* conn, const char* value)
+{
+    double window;
+    const char* const endptr = gu_str2dbl(value, &window);
+
+    if (window >= 0.0 && *endptr == '\0') {
+        if (window == conn->params.fc_auto_evict_window) return 0;
+
+        conn->params.fc_auto_evict_window = window;
+        update_fc_auto_evict_params(conn);
+        gcs_sm_enable_fc_auto_evict(conn->sm, window > 0);
+        gu_config_set_double (conn->config, GCS_PARAMS_FC_AUTO_EVICT_WND,
+                              window);
+        return 0;
+    }
+    else {
+        return -EINVAL;
+    }
+}
+
+static long
+_set_fc_auto_evict_threshold (gcs_conn_t* conn, const char* value)
+{
+    double threshold;
+    const char* const endptr = gu_str2dbl(value, &threshold);
+
+    if (threshold > 0.0 && threshold <= 1.0 && *endptr == '\0') {
+        if (threshold == conn->params.fc_auto_evict_threshold) return 0;
+
+        conn->params.fc_auto_evict_threshold = threshold;
+        update_fc_auto_evict_params(conn, false);
+        gu_config_set_double (conn->config, GCS_PARAMS_FC_AUTO_EVICT_TH,
+                              threshold);
+        return 0;
+    }
+    else {
+        return -EINVAL;
+    }
+}
+
+static long
 _set_sync_donor (gcs_conn_t* conn, const char* value)
 {
     bool sd;
@@ -2826,6 +2906,12 @@ long gcs_param_set  (gcs_conn_t* conn, const char* key, const char *value)
     }
     else if (!strcmp (key, GCS_PARAMS_FC_DEBUG)) {
         return _set_fc_debug (conn, value);
+    }
+    else if (!strcmp (key, GCS_PARAMS_FC_AUTO_EVICT_WND)) {
+        return _set_fc_auto_evict_window (conn, value);
+    }
+    else if (!strcmp (key, GCS_PARAMS_FC_AUTO_EVICT_TH)) {
+        return _set_fc_auto_evict_threshold (conn, value);
     }
     else if (!strcmp (key, GCS_PARAMS_SYNC_DONOR)) {
         return _set_sync_donor (conn, value);

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -396,7 +396,7 @@ gcs_vote (gcs_conn_t* conn, const gu::GTID& gtid, uint64_t code,
 extern bool
 gcs_register_params (gu_config_t* conf);
 
-/*! sets the key to a given value
+/*! sets the key to a given value (isn't thread safe)
  *
  * @return 0 in case of success, 1 if key not found or negative error code */
 extern long

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -250,6 +250,8 @@ core_error (core_state_t state)
  * restart flag may be raised if configuration changes and new nodes are
  * added - that would require all previous members to resend partially sent
  * actions.
+ *
+ * @return negative error code, 0 in case of success.
  */
 static inline ssize_t
 core_msg_send (gcs_core_t*    core,
@@ -294,6 +296,8 @@ core_msg_send (gcs_core_t*    core,
 /*!
  * Repeats attempt at sending the message if -EAGAIN was returned
  * by core_msg_send()
+ *
+ * @return negative error code, 0 in case of success.
  */
 static inline ssize_t
 core_msg_send_retry (gcs_core_t*    core,

--- a/gcs/src/gcs_core.hpp
+++ b/gcs/src/gcs_core.hpp
@@ -157,7 +157,10 @@ extern int
 gcs_core_send_vote (gcs_core_t* core, const gu::GTID& gtid, int64_t code,
                     const void* msg, size_t msg_len);
 
-/* sends flow control message */
+/* sends flow control message.
+ *
+ * @return negative error code, 0 in case of success.
+ */
 extern ssize_t
 gcs_core_send_fc (gcs_core_t* core, const void* fc, size_t fc_size);
 

--- a/gcs/src/gcs_params.cpp
+++ b/gcs/src/gcs_params.cpp
@@ -11,12 +11,15 @@
 #include "gu_config.hpp" // gu::Config::Flag
 
 #include <cerrno>
+#include <cfloat>
 
 const char* const GCS_PARAMS_FC_FACTOR         = "gcs.fc_factor";
 const char* const GCS_PARAMS_FC_LIMIT          = "gcs.fc_limit";
 const char* const GCS_PARAMS_FC_MASTER_SLAVE   = "gcs.fc_master_slave";
 const char* const GCS_PARAMS_FC_SINGLE_PRIMARY = "gcs.fc_single_primary";
 const char* const GCS_PARAMS_FC_DEBUG          = "gcs.fc_debug";
+const char* const GCS_PARAMS_FC_AUTO_EVICT_WND = "gcs.fc_auto_evict_window";
+const char* const GCS_PARAMS_FC_AUTO_EVICT_TH  = "gcs.fc_auto_evict_threshold";
 const char* const GCS_PARAMS_SYNC_DONOR        = "gcs.sync_donor";
 const char* const GCS_PARAMS_MAX_PKT_SIZE      = "gcs.max_packet_size";
 const char* const GCS_PARAMS_RECV_Q_HARD_LIMIT = "gcs.recv_q_hard_limit";
@@ -35,6 +38,8 @@ static const char* const GCS_PARAMS_FC_LIMIT_DEFAULT          = "16";
 static const char* const GCS_PARAMS_FC_MASTER_SLAVE_DEFAULT   = "no";
 static const char* const GCS_PARAMS_FC_SINGLE_PRIMARY_DEFAULT = "no";
 static const char* const GCS_PARAMS_FC_DEBUG_DEFAULT          = "0";
+static const char* const GCS_PARAMS_FC_AUTO_EVICT_WND_DEFAULT = "0";
+static const char* const GCS_PARAMS_FC_AUTO_EVICT_TH_DEFAULT  = "0.75";
 static const char* const GCS_PARAMS_SYNC_DONOR_DEFAULT        = "no";
 static const char* const GCS_PARAMS_MAX_PKT_SIZE_DEFAULT      = "64500";
 static ssize_t const GCS_PARAMS_RECV_Q_HARD_LIMIT_DEFAULT     = SSIZE_MAX;
@@ -63,6 +68,12 @@ gcs_params_register(gu_config_t* conf)
     ret |= gu_config_add (conf, GCS_PARAMS_FC_DEBUG,
                           GCS_PARAMS_FC_DEBUG_DEFAULT,
                           gu::Config::Flag::type_integer);
+    ret |= gu_config_add (conf, GCS_PARAMS_FC_AUTO_EVICT_WND,
+                          GCS_PARAMS_FC_AUTO_EVICT_WND_DEFAULT,
+                          gu::Config::Flag::type_double);
+    ret |= gu_config_add (conf, GCS_PARAMS_FC_AUTO_EVICT_TH,
+                          GCS_PARAMS_FC_AUTO_EVICT_TH_DEFAULT,
+                          gu::Config::Flag::type_double);
     ret |= gu_config_add (conf, GCS_PARAMS_SYNC_DONOR,
                           GCS_PARAMS_SYNC_DONOR_DEFAULT,
                           gu::Config::Flag::type_bool);
@@ -221,6 +232,14 @@ gcs_params_init (struct gcs_params* params, gu_config_t* config)
 
     if ((ret = params_init_long (config, GCS_PARAMS_FC_DEBUG, 0, LONG_MAX,
                                  &params->fc_debug))) return ret;
+
+    if ((ret = params_init_double (config, GCS_PARAMS_FC_AUTO_EVICT_WND,
+                                   0.0, DBL_MAX,
+                                   &params->fc_auto_evict_window))) return ret;
+
+    if ((ret = params_init_double (config, GCS_PARAMS_FC_AUTO_EVICT_TH,
+                                   0.0 + 1.e-9, 1.0,
+                                   &params->fc_auto_evict_threshold))) return ret;
 
     if ((ret = params_init_long (config, GCS_PARAMS_MAX_PKT_SIZE, 0,LONG_MAX,
                                  &params->max_packet_size))) return ret;

--- a/gcs/src/gcs_params.hpp
+++ b/gcs/src/gcs_params.hpp
@@ -17,6 +17,8 @@ struct gcs_params
     long    fc_base_limit;
     long    max_packet_size;
     long    fc_debug;
+    double  fc_auto_evict_window;
+    double  fc_auto_evict_threshold;
     bool    fc_single_primary;
     bool    sync_donor;
 };
@@ -25,6 +27,8 @@ extern const char* const GCS_PARAMS_FC_FACTOR;
 extern const char* const GCS_PARAMS_FC_LIMIT;
 extern const char* const GCS_PARAMS_FC_MASTER_SLAVE;
 extern const char* const GCS_PARAMS_FC_DEBUG;
+extern const char* const GCS_PARAMS_FC_AUTO_EVICT_WND;
+extern const char* const GCS_PARAMS_FC_AUTO_EVICT_TH;
 extern const char* const GCS_PARAMS_SYNC_DONOR;
 extern const char* const GCS_PARAMS_MAX_PKT_SIZE;
 extern const char* const GCS_PARAMS_RECV_Q_HARD_LIMIT;

--- a/gcs/src/gcs_sm.hpp
+++ b/gcs/src/gcs_sm.hpp
@@ -30,8 +30,8 @@ gcs_sm_user_t;
 
 typedef struct gcs_sm_stats
 {
-    long long sample_start;// beginning of the sample period
-    long long pause_start; // start of the pause
+    long long sample_start;// beginning of the sample period (from the last flush)
+    long long pause_start; // start of the last pause
     long long paused_ns;     // total nanoseconds paused
     long long paused_sample; // paused_ns at the beginning of the sample
     long long send_q_samples;
@@ -498,7 +498,7 @@ gcs_sm_interrupt (gcs_sm_t* sm, long handle)
 }
 
 /*!
- * Each call to this function resets stats and starts new sampling interval
+ * Copies send monitor statistics to the variables
  *
  * @param q_len      current send queue length
  * @param q_len_avg  set to an average number of preceding users seen by each
@@ -518,7 +518,11 @@ gcs_sm_stats_get (gcs_sm_t*  sm,
                   long long* paused_ns,
                   double*    paused_avg);
 
-/*! resets average/max/min stats calculation */
+/*!
+ * Resets average/max/min stats calculation
+ *
+ * Each call to this function resets stats and starts new sampling interval.
+ */
 extern void
 gcs_sm_stats_flush(gcs_sm_t* sm);
 

--- a/gcs/src/gcs_sm.hpp
+++ b/gcs/src/gcs_sm.hpp
@@ -14,6 +14,7 @@
 #include "gu_datetime.hpp"
 #include <galerautils.h>
 #include <errno.h>
+#include <vector>
 
 #ifdef GCS_SM_CONCURRENCY
 #define GCS_SM_CC sm->cc
@@ -60,6 +61,12 @@ typedef struct gcs_sm
     long          cc;
 #endif /* GCS_SM_CONCURRENCY */
     bool          pause;
+    bool          fc_auto_evict; // is FC auto eviction enabled
+    /*
+      Sequence of pause and continue moments (first element is always pause),
+      eventually truncated to last GCS_PARAMS_FC_AUTO_EVICT_WND seconds.
+     */
+    std::vector<long long> pauses_window;
     gu::datetime::Period wait_time;
 
 #ifdef GCS_SM_DEBUG
@@ -111,9 +118,16 @@ gcs_sm_dump_state(gcs_sm_t* sm, FILE* file);
  *
  * @param len size of the monitor, should be a power of 2
  * @param n   concurrency parameter (how many users can enter at the same time)
+ * @param fc_auto_evict is FC auto eviction enabled
  */
 extern gcs_sm_t*
-gcs_sm_create (long len, long n);
+gcs_sm_create (long len, long n, bool fc_auto_evict = false);
+
+/*!
+ * Enables or disables FC auto eviction
+ */
+extern void
+gcs_sm_enable_fc_auto_evict(gcs_sm_t* sm, bool fc_auto_evict = true);
 
 /*!
  * Closes monitor for entering and makes all users to exit with error.
@@ -424,6 +438,12 @@ gcs_sm_pause (gcs_sm_t* sm)
     /* don't pause closed monitor */
     if (gu_likely(0 == sm->ret) && !sm->pause) {
         sm->stats.pause_start = gu_time_monotonic();
+        if (sm->fc_auto_evict) {
+            /* sm->pause guarantees that sequence of pauses and continues
+               will be alternating and pause will be the first in it */
+            assert(!(sm->pauses_window.size() % 2));
+            sm->pauses_window.push_back(sm->stats.pause_start);
+        }
         sm->pause = true;
     }
     GCS_SM_HIST_LOG("paused");
@@ -433,6 +453,11 @@ gcs_sm_pause (gcs_sm_t* sm)
 static inline void
 _gcs_sm_continue_common (gcs_sm_t* sm)
 {
+    /* Skip the continue if complementing it pause wasn't collected.
+       It can occur if we enable sm->fc_auto_evict in the middle of a pause. */
+    if (sm->fc_auto_evict && sm->pauses_window.size() % 2) {
+        sm->pauses_window.push_back(gu_time_monotonic());
+    }
     sm->pause = false;
 
     _gcs_sm_wake_up_next(sm); /* wake up next waiter if any */
@@ -496,6 +521,16 @@ gcs_sm_interrupt (gcs_sm_t* sm, long handle)
 
     return ret;
 }
+
+/*!
+ * Calculates total nanoseconds of pause in the last window_ns and optionally
+ * erases the outdated statistics.
+ *
+ * Pause can exceed the window if it's overlapped by pause-continue interval.
+ */
+extern long long
+gcs_sm_paused_in_window_get (gcs_sm_t* const sm, long long window_ns,
+                             bool erase_outdated = true);
 
 /*!
  * Copies send monitor statistics to the variables


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3760

Problem:
We want to evict a node if it slows down a whole cluster due to the flow control.

Solution:
We introduce two variables: gcs.fc_auto_evict_window and gcs.fc_auto_evict_threshold. If the node pauses in FC more then "threshold * window" in the last "window" seconds frame, node will just abort.

The abortion can be problematic if we have 2-nodes cluster. From the side of other nodes this will be indistinguishable from the crash of the lagging node.