### PR TITLE
PXC-3047: Server hangs up if cannot connect to members PXC 8.0

### DIFF
--- a/galera/tests/defaults_check.cpp
+++ b/galera/tests/defaults_check.cpp
@@ -104,6 +104,7 @@ static const char* Defaults[] =
     "pc.version",                  "0",
     "pc.wait_prim",                "true",
     "pc.wait_prim_timeout",        "PT30S",
+    "pc.wait_restored_prim_timeout", "PT0S",
     "pc.weight",                   "1",
     "protonet.backend",            "asio",
     "protonet.version",            "0",

--- a/gcomm/src/conf.cpp
+++ b/gcomm/src/conf.cpp
@@ -120,6 +120,8 @@ std::string const gcomm::Conf::PcBootstrap = PcPrefix + "bootstrap";
 std::string const gcomm::Conf::PcWaitPrim = PcPrefix + "wait_prim";
 std::string const gcomm::Conf::PcWaitPrimTimeout =
     PcPrefix + "wait_prim_timeout";
+std::string const gcomm::Conf::PcWaitRestoredPrimTimeout =
+    PcPrefix + "wait_restored_prim_timeout";
 std::string const gcomm::Conf::PcWeight = PcPrefix + "weight";
 std::string const gcomm::Conf::PcRecovery = PcPrefix + "recovery";
 
@@ -188,6 +190,7 @@ gcomm::Conf::register_params(gu::Config& cnf)
     GCOMM_CONF_ADD        (PcBootstrap);
     GCOMM_CONF_ADD_DEFAULT(PcWaitPrim);
     GCOMM_CONF_ADD_DEFAULT(PcWaitPrimTimeout);
+    GCOMM_CONF_ADD_DEFAULT(PcWaitRestoredPrimTimeout);
     GCOMM_CONF_ADD_DEFAULT(PcWeight);
     GCOMM_CONF_ADD_DEFAULT(PcRecovery);
 

--- a/gcomm/src/defaults.cpp
+++ b/gcomm/src/defaults.cpp
@@ -58,6 +58,7 @@ namespace gcomm
     std::string const Defaults::PcVersion               = "0";
     std::string const Defaults::PcWaitPrim              = "true";
     std::string const Defaults::PcWaitPrimTimeout       = "PT30S";
+    std::string const Defaults::PcWaitRestoredPrimTimeout = "PT0S";
     std::string const Defaults::PcWeight                = "1";
     std::string const Defaults::PcRecovery              = "true";
 }

--- a/gcomm/src/defaults.hpp
+++ b/gcomm/src/defaults.hpp
@@ -51,6 +51,7 @@ namespace gcomm
         static std::string const PcVersion                ;
         static std::string const PcWaitPrim               ;
         static std::string const PcWaitPrimTimeout        ;
+        static std::string const PcWaitRestoredPrimTimeout;
         static std::string const PcWeight                 ;
         static std::string const PcRecovery               ;
     };
@@ -138,6 +139,8 @@ namespace gcomm
                                                 gu::Config::Flag::type_bool;
         static const int PcWaitPrimTimeout    = gu::Config::Flag::read_only |
                                                 gu::Config::Flag::type_duration;
+        static const int PcWaitRestoredPrimTimeout    = gu::Config::Flag::read_only |
+                                                        gu::Config::Flag::type_duration;
         static const int PcWeight             = gu::Config::Flag::type_integer;
         static const int PcRecovery           = gu::Config::Flag::read_only |
                                                 gu::Config::Flag::type_bool;

--- a/gcomm/src/gcomm/conf.hpp
+++ b/gcomm/src/gcomm/conf.hpp
@@ -411,6 +411,11 @@ namespace gcomm
         static std::string const PcWaitPrimTimeout;
 
         /*!
+         * @brief Timeout on waiting for restored primary component
+         */
+        static std::string const PcWaitRestoredPrimTimeout;
+
+        /*!
          * @brief Node weight in prim comp voting
          */
         static std::string const PcWeight;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3047

Problem:
The server with a view stored in gvwstate.dat file hangs up infinitely, when it starts, but can not connect to other nodes.

Cause:
When the node starts, it waits for primary component for pc.wait_prim_timeout seconds. If PC is not reached, the node exits. However, this timeout is not respected in case of the PC view restored from the file. In such a case node just joins the cluster and waits for PC infinitely.

Solution:
pc.wait_prim_timeout defaults to 30s and it may be not enough for cluster recovery after failure. Introduce new configuration option pc.wait_restored_prim_timeout with default of 0s.
If set to default, there is the old behavior - the node waits infinitely if set to any other value, the node waits for requested time (sec) for PC and exits if not reached.