### PR TITLE
PXC-4221: PXC 8.0.33 refresh - Q2 2023

### DIFF
--- a/gcs/src/gcs_act_cchange.cpp
+++ b/gcs/src/gcs_act_cchange.cpp
@@ -101,7 +101,9 @@ gcs_act_cchange::gcs_act_cchange(const void* const cc_buf, int const cc_size)
     const char* b(static_cast<const char*>(cc_buf));
     Version const cc_ver(_version(b[0]));
     int const check_len(_checksum_len(cc_ver));
-    int const check_offset(cc_size - check_len);
+    if (check_len > cc_size) abort();
+
+    size_t const check_offset(cc_size - check_len);
 
     checksum_t check;
     _checksum(cc_ver, cc_buf, check_offset, check);

--- a/gcs/src/unit_tests/gcs_proto_test.cpp
+++ b/gcs/src/unit_tests/gcs_proto_test.cpp
@@ -51,7 +51,9 @@ START_TEST (gcs_proto_test)
                   " - increase send action length");
 
     // write action to the buffer, it should not fit
-    strncpy (static_cast<char*>(const_cast<void*>(frg_send.frag)), act_send_ptr, frg_send.frag_len);
+    char* frg = static_cast<char*>(const_cast<void*>(frg_send.frag));
+    int cnt = std::min(strlen(frg)+1, frg_send.frag_len);
+    memcpy(frg, act_send_ptr, cnt);
     act_send_ptr += frg_send.frag_len;
 
     // message was sent and received, now parse the header


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4221

Fixed compilation errors for gcc-12.

--Wstringop-overflow specified bound 18446744073709551615 exceeds maximum object size 9223372036854775807
was caused by compiler detecting possibly negative number passed to std::copy()

error: '__builtin_strncpy' output may be truncated copying 12 bytes from a string of length 20 [-Werror=stringop-truncation] was caused by obvious truncation of the string.