### PR TITLE
PXC-4221: PXC 8.0.33 refresh - Q2 2023 (Fix compilation error)

### DIFF
--- a/gcs/src/gcs_act_cchange.cpp
+++ b/gcs/src/gcs_act_cchange.cpp
@@ -168,7 +168,7 @@ gcs_act_cchange::gcs_act_cchange(const void* const cc_buf, int const cc_size)
         memb.push_back(m);
     }
 
-    assert(b - static_cast<const char*>(cc_buf) <= check_offset);
+    assert(static_cast<size_t>(b - static_cast<const char*>(cc_buf)) <= check_offset);
 }
 
 static size_t


### PR DESCRIPTION
PXC-4221: PXC 8.0.33 refresh - Q2 2023

https://jira.percona.com/browse/PXC-4221

    Fixed compilation error
    
    [ 33%] Building CXX object percona-xtradb-cluster-galera/gcs/src/CMakeFiles/gcs4garb.dir/gcs_fifo_lite.cpp.o
    In file included from galera/galerautils/src/gu_fnv.h:30,
                     from galera/galerautils/src/gu_hash.h:29,
                     from galera/galerautils/src/gu_gtid.hpp:11,
                     from galera/gcs/src/gcs.hpp:20,
                     from galera/gcs/src/gcs_act_cchange.cpp:5:
    galera/gcs/src/gcs_act_cchange.cpp: In constructor ‘gcs_act_cchange::gcs_act_cchange(const void*, int)’:
    galera/gcs/src/gcs_act_cchange.cpp:171:49: error: comparison of integer expressions of different signedness: ‘long int’ and ‘const size_t’ {aka ‘const long unsigned int’} [-Werror=sign-compare]
      171 |     assert(b - static_cast<const char*>(cc_buf) <= check_offset);
          |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~