### PR TITLE
PXC-4233: Cluster state interruption during NBO may lead to permanent cluster lock

### DIFF
--- a/galera/src/galera_service_thd.cpp
+++ b/galera/src/galera_service_thd.cpp
@@ -90,6 +90,10 @@ galera::ServiceThd::thd_func (void* arg)
                     log_warn << "Exception releasing seqno "
                              << data.release_seqno_ << ": " << e.what();
                 }
+                if(data.clear_release_seqno_) {
+                    data.release_seqno_ = 0;
+                    data.clear_release_seqno_ = false;
+                }
             }
         }
     }
@@ -185,13 +189,14 @@ galera::ServiceThd::report_last_committed(gcs_seqno_t const seqno,
 }
 
 void
-galera::ServiceThd::release_seqno(gcs_seqno_t seqno)
+galera::ServiceThd::release_seqno(gcs_seqno_t seqno, bool reset)
 {
     gu::Lock lock(mtx_);
 
     if (data_.release_seqno_ < seqno)
     {
         data_.release_seqno_ = seqno;
+        data_.clear_release_seqno_ = reset;
 
         if (data_.act_ == A_NONE) cond_.signal();
 

--- a/galera/src/galera_service_thd.hpp
+++ b/galera/src/galera_service_thd.hpp
@@ -39,7 +39,7 @@ namespace galera
         void report_last_committed (gcs_seqno_t seqno, bool const report = true);
 
         /*! release write sets up to and including seqno */
-        void release_seqno (gcs_seqno_t seqno);
+        void release_seqno (gcs_seqno_t seqno, bool reset = false);
 
     private:
 
@@ -49,11 +49,13 @@ namespace galera
         {
             gu::GTID    last_committed_;
             gcs_seqno_t release_seqno_;
+            bool        clear_release_seqno_;
             uint32_t    act_;
 
             Data() :
                 last_committed_(),
                 release_seqno_ (0),
+                clear_release_seqno_(false),
                 act_           (A_NONE)
             {}
         };

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -441,7 +441,7 @@ wsrep_status_t galera::ReplicatorSMM::close()
 {
     gu::Lock lock(closing_mutex_);
 
-#if PXC 
+#if PXC
     /* If IST is prepared waiting for SST to complete and if SST fails
     then ensure that IST is signaled about the interruption or failure.
     IST is waiting on condition variable to get signaled after SST

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -1836,8 +1836,12 @@ void ReplicatorSMM::ist_cc(const gcs_action& act, bool must_apply,
              * Order of these calls is essential: trx_params_.version_ may
              * be altered by establish_protocol_versions() */
             establish_protocol_versions(conf.repl_proto_ver);
+            /* Do not reset NBO waiters. It may be that this node re-joins
+               primary component and NBO already finished in primary component,
+               so if we reset nbo waiters, we may not get notifications from
+               some nodes. The only way is to learn the history through IST */
             cert_.adjust_position(*view_info, gu::GTID(conf.uuid, conf.seqno),
-                                  trx_params_.version_);
+                                  trx_params_.version_, false);
             // record CC related state seqnos, needed for IST on DONOR
             record_cc_seqnos(conf.seqno, "preload");
             ::free(view_info);

--- a/galera/tests/certification_check.cpp
+++ b/galera/tests/certification_check.cpp
@@ -49,7 +49,7 @@ namespace
                 gu_init(nullptr, [](wsrep_pfs_instr_type_t,
                                     wsrep_pfs_instr_ops_t,
                                     wsrep_pfs_instr_tag_t, void **,
-                                    void **, const void *) {});             
+                                    void **, const void *) {});
             }
         }                                 init_;
         galera::ProgressCallback<int64_t> gcache_pcb_;

--- a/gcomm/src/evs_proto.cpp
+++ b/gcomm/src/evs_proto.cpp
@@ -238,7 +238,7 @@ gcomm::evs::Proto::~Proto()
 
 
 bool
-gcomm::evs::Proto::set_param(const std::string& key, const std::string& val, 
+gcomm::evs::Proto::set_param(const std::string& key, const std::string& val,
                             Protolay::sync_param_cb_t& sync_param_cb)
 {
     if (key == gcomm::Conf::EvsVersion)
@@ -2582,6 +2582,8 @@ void gcomm::evs::Proto::handle_up(const void* cid,
 
         default:
             log_fatal << "exception caused by message: " << msg;
+            log_fatal << "errno: " << e.get_errno();
+            log_fatal << "what: " << e.what();
             std::cerr << " state after handling message: " << *this;
             throw;
         }
@@ -3220,7 +3222,6 @@ void gcomm::evs::Proto::deliver_trans()
                 }
                 else
                 {
-                    gcomm_assert(mn.operational() == false);
                     log_info << "filtering out trans message higher than "
                              << "install message hs "
                              << mn.im_range().hs()

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -1782,6 +1782,11 @@ static void *gcs_recv_thread (void *arg)
                      rcvd.act.buf, rcvd.act.buf_len,
                      gcs_act_type_to_str(rcvd.act.type), rcvd.sender_idx,
                      rcvd.id);
+            if (rcvd.act.buf)
+            {
+                gcs_gcache_free (conn->gcache, rcvd.act.buf);
+                rcvd.act.buf = nullptr;
+            }
         }
         else
         {
@@ -1812,7 +1817,7 @@ static void *gcs_recv_thread (void *arg)
         /* In case of error call _close() to release repl_q waiters. */
         (void)_close(conn, false);
         gcs_shift_state (conn, GCS_CONN_CLOSED);
-#endif /* PXC */ 
+#endif /* PXC */
     }
     gu_info ("RECV thread exiting %d: %s", ret, strerror(-ret));
 
@@ -2556,7 +2561,7 @@ gcs_join (gcs_conn_t* conn, const gu::GTID& gtid, int const code)
     // in the gcs_join() function to return from it immediately
     // if the node's communication channel was closed:
 
-    if (conn->state >= GCS_CONN_CLOSED) 
+    if (conn->state >= GCS_CONN_CLOSED)
     {
       return GCS_CLOSED_ERROR;
     }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4233

Problem:
DDL transaction (ALTER TABLE) executed in NBO mode can cause BF-BF
conflict with other DML transaction (INSERT) which tries to modify data
in the same table.
This is a known limitation that both cannot be executed at the same time
but the problem is that BF-BF causes all cluster nodes abort and cluster
outage.

Cause:
When NBO transaction is replicated, two things happen:
1. On local node TOI transaction indicating start of NBO ends, releasing
Commit and Apply Monitors in Galera. This is end of NBO phase 1. Then
the DDL goes as normal transaction. At the end we wait for NBO to
finish (NBO phase 2 begin). At this moment we wait for all cluster nodes
to confirm completion of NBO execution. We still hold all MDL locks
related to the transaction
2. On remote node, applier thread just spawns NBO thread which is
responsible for applying all DDL changes. Then applier thread finishes
processing TOI transaction related to local node's NBO phase 1.
At this moment no MDL locks related to NBO are acquired.
Commit and Apply Order Monitors are released as well.

At the moment, when on remote node NBO applier didn't acuire any MDL
locks yet, but the NBO-triggering TOI finished, another DML transaction
modifying the same table is free to go (no MDL conflicts).
Certification flow was implemented in the way that it considered only
other TOI and NBO transactions, ignoring normal and streaming
replication transactions. So the DML transaction was replicated.

Back to local node. It waits for NBO confirmation from remote node.
Replicated DML transaction arrives and is being applied. Applier thread
is attempting to lock MDL lock, which is already held by local NBO
transaction which ends up with BF-BF abort.

Solution:
Modify certification flow in the way that it checks for conflicts
against ongoing NBO transactions also for regular and streaming
replication transactions. If the transaction conflicts with ongoing NBO
transaction, it fails with deadlock error (the original behavior for
TOI)

After fixing the above, several issues were uncovered which were also
fixed:
1. If the node is partitioned because of network issues, and it just
sends nbo-end writeset, it may happen that the writeset fails to be sent
and is marked with rcvd->id = -ERESTART in gcs_group_handle_act_msg.
Then such a writeset is received by gcs_recv_thread but it is discarded.
In such a case there was missing freeing of gcache buffer related to
this writeset. Buffer stayed allocated in GCache forever and after some
time it prevented further allocations from ring buffer. As the solution
added missing gcache free. Note that this issue was present for all
calls of gcs_.sendv(). gcs_.replv() waits for writeset to be replicated
and has the logic of freeing buffers related to failed actions.

2. During aggressive network outages it was observed a rare situation
when in deliver_trans() we hit the assert
gcomm_assert(mn.operational() == false);.
The assert was removed allowing the flow to filter-out the message
and continue.

3. If the certification position was moved backward, service_thd was
triggered to release old seqno from gcache. This seqno was latched
inside service_thd preventing further releases up to the latched value.
Added the logic preventing latching of the seqno in service_thd.

4. When IST is received by the node rejoining the cluster,
Certification::adjust_position() is called. It was unconditionally
reseting NBO waiters, assuming all nodes to resend NBO-end message.
However, it may happen that NBO-end related writesets originating from
some other nodes are present in IST only and other nodes finished
processing the related NBO. It happens when partitioned node sent it's
NBO-end writeset just before partitioning, received NBO-end messages
from some nodes, but didn't receive NBO-end messages from other nodes.
Then other nodes agree on NBO end, erase their NBO contexts, sending
their NBO-end messages. The only way to learn about NBO end on other
nodes is to read these events from IST, but IST doesn't contain already
received NBO-end messages. If we reset NBO-wait context we will never
receive NBO-end events from nodes that already sent them before node
partitioning. As the solution skip NBO-end waiters reset during IST.