### PR TITLE
PXC-4288: Galera Arbitrator (garbd) uses 100% CPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,10 +101,6 @@ include(cmake/maintainer_mode.cmake)
 include(CTest)
 enable_testing()
 
-if(DEFINED WITH_PERFSCHEMA_STORAGE_ENGINE)
-  add_definitions(-DHAVE_PSI_INTERFACE=1)
-endif()
-
 # Suppress warnings for all clang versions
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   remove_compile_flags(-Wdeprecated -Wdeprecated-dynamic-exception-spec -Winconsistent-missing-destructor-override -Wshadow-field -Wheader-hygiene)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -61,8 +61,10 @@ endif()
 
 add_definitions(-DPXC)
 
-if (GALERA_PSI_INTERFACE)
-  add_definitions(-DWITH_PSI_INTERFACE)
+# GALERA_PSI_INTERFACE comes from percona-xtradb-cluster-galera/CMakeLists.txt
+# WITH_PERFSCHEMA_STORAGE_ENGINE comes from server's cmake files
+if (GALERA_PSI_INTERFACE AND DEFINED WITH_PERFSCHEMA_STORAGE_ENGINE)
+  add_definitions(-DHAVE_PSI_INTERFACE=1)
 endif()
 
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4288

Problem:
Galera Arbitrator (garbd) uses 100% CPU

Cause:
PXC introduces P_S instrumentation for some of Galera mutexes and condition variables. For this, the library needs to be compiled with -DHAVE_PSI_INTERFACE=1.
As there is no PSI interface provider in the case of garbd, it has to be compiled without -DHAVE_PSI_INTERFACE=1.
Up to 8.0.32 we used scons for building Galera lib and garbd. Build process was done in 2 attempts:
1. Galera lib with -DHAVE_PSI_INTERFACE=1
2. garbd without -DHAVE_PSI_INTERFACE=1 PXC 8.0.33 switched  CMake to build Galera library and garbd and added -DHAVE_PSI_INTERFACE=1 globally, so both were compiled with this option. garbd registers and empty function in place of PSI instrumentation callback so effectively all mutexes and condition variables were noops. This caused observed 100% CPU utilization because of event processing loop turning around instead of waiting on a condition variable. Most probably other synchronization issues took place as well.

Solution:
Instead of defining separate CMake targets for garbd (gcomm, gcache, galerautilsxx) we always assume compilation with
-DHAVE_PSI_INTERFACE=1. Previously empty PSI callback was implemented to provide mutex and condition operations (similarly to wsrep_mysqld.cc wsrep_pfs_instr_cb function). So we use a kind of dependency injection pattern, where PSI instrumentation interface is always injected into Galera utils layer.
We still use plain Galera utils Mutex and Cond objects in case of compilation with GALERA_PSI_INTERFACE=OFF (Galera option) or WITH_PERFSCHEMA_STORAGE_ENGINE=OFF (server option) if