### PR TITLE
PXC-4296: garbd 8.0.33 reports wrong version

### DIFF
--- a/garb/CMakeLists.txt
+++ b/garb/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(garbd
 target_compile_definitions(garbd
   PRIVATE
   -DGALERA_VER="${GALERA_VERSION}"
-  -DGALERA_REV="${GALERA_REVISION}"
+  -DGALERA_REV="${GALERA_GIT_REVISION}"
   )
 
 # TODO: Fix.


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4296

Problem:
Revision part of version number for garbd was missing.

Cause:
CMake used GALERA_REVISION variable instead of GALERA_GIT_REVISION for garbd.

Solution:
Use GALERA_GIT_REVISION in garbd cmake.