### PR TITLE
PXC-4167: Node crashes with Transport endpoint is not connected

### DIFF
--- a/galerautils/src/gu_asio_stream_react.cpp
+++ b/galerautils/src/gu_asio_stream_react.cpp
@@ -926,9 +926,11 @@ void gu::AsioAcceptorReact::accept_handler(
     set_socket_options(socket->socket_);
     socket->set_non_blocking(true);
     socket->prepare_engine(true);
+    std::string remote_ip;
     try
     {
        socket->assign_addresses();
+       remote_ip = gu::unescape_addr(::escape_addr(socket->socket_.remote_endpoint().address()));
     }
     catch(const asio::system_error& e)
     {
@@ -936,7 +938,6 @@ void gu::AsioAcceptorReact::accept_handler(
         async_accept(handler);
         return;
     }
-    std::string remote_ip = gu::unescape_addr(::escape_addr(socket->socket_.remote_endpoint().address()));
     auto connection_allowed(gu::allowlist_value_check(WSREP_ALLOWLIST_KEY_IP, remote_ip));
     if (connection_allowed == false)
     {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4167

Problem:
PXC-4167 was solved by the upstream commit
930c016108d7086b472ad7a8b9d0f6989202b48a, where catching of possible exception thrown by assign_address() (which calls
socket::remote_endpoint() where the actual call is done).

However, after that fix, it was reported several times that the issue rarely, but still occurs and the server fails with the following error:

terminate called after throwing an instance of 'std::system_error' what():  remote_endpoint: Transport endpoint is not connected

Cause:
Deeper analysis of the code shows, that such an exception can be thrown only from basic_socket::remote_endpoint(). The above-mentioned fix didn't consider the call of this method which is done just after assign_address() wrapped in try ... catch block.

Solution:
Extend the upstream fix to catch the uncaught exception.