### PR TITLE
PXC-4365: PXC nodes leave cluster when row size is too large and has more than 3 NVARCHAR columns.

### DIFF
--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -1492,7 +1492,13 @@ gcs_core_send_vote (gcs_core_t* const core, const gu::GTID& gtid, int64_t code,
     assert(cmsg.uuid() != GU_UUID_NIL);
     int const cmsg_size(cmsg.serial_size());
 
-    char vmsg[1024] = { 0, }; // try to fit in one ethernet frame
+    // Max length of the error message sent by the server is 2*MAX_SLAVE_ERRMSG
+    // i.e, 2048 bytes (defined in wsrep_store_error()).
+    //
+    // So the buffer length should be 2048 + size of coded message
+    const size_t buffer_length = 2048 + cmsg_size;
+
+    char vmsg[buffer_length] = { 0, };
     assert(cmsg_size < int(sizeof(vmsg)));
 
     ::memcpy(&vmsg[0], cmsg(), cmsg_size);


### PR DESCRIPTION
Problem
-------
Server evicts from the cluster if the query failed with a long error message > 1024 characters.

Analysis
--------
While creating a table, if the table structure has any NVARCHAR columns, the server will generate a warning saying

    NATIONAL/NCHAR/NVARCHAR implies the character set UTF8MB3, which will
    be replaced by UTF8MB4 in a future release. Please consider using
    CHAR(x) CHARACTER SET UTF8MB4 in order to be unambiguous.

If row length of the new table exceeds the max row length supported by the storage engine, then the query will fail with error

    Row size too large. The maximum row size for the used table type, not
    counting BLOBs, is 65535. This includes storage overhead, check the
    manual. You have to change some columns to TEXT or BLOBs

When we try to create a table having nvarchar columns and if the total row length exceeds the value supported by storage enging, then the query fails with both warnings and error.

When such a query fails in a clustered environment, warnings and errors generated by the query are concatenated into a single string and is sent to the cluster to peform inconsistency voting.

However, if this concatenated error message has more than 991 characters, then it undergoes truncation to 991 characters which caused the voting mechanism to calculate different votes, eventually resulting in node eviction from the cluster.

Solution
--------
The size of the buffer (used while sending the vote message to the cluster) has been increased to 2070 characters (2048 for error message + 32 for coded message) to accomodate even the longest error message sent by server.

Note
-----
Testcase will be added through a separate PR to the server repo.