### PR TITLE
PXC-4316: Nodes "changing identity" can prevents primary groups

### DIFF
--- a/gcomm/src/evs_proto.cpp
+++ b/gcomm/src/evs_proto.cpp
@@ -2559,6 +2559,12 @@ void gcomm::evs::Proto::handle_up(const void* cid,
         return;
     }
 
+    if (um.source_view_id() == V_IDENTITY_CHANGE)
+    {
+        send_up(rb, um);
+        return;
+    }
+
     gcomm_assert(um.source() != UUID::nil());
 
     try

--- a/gcomm/src/gcomm/view.hpp
+++ b/gcomm/src/gcomm/view.hpp
@@ -29,7 +29,8 @@ namespace gcomm
         V_REG      = 0,
         V_TRANS    = 1,
         V_NON_PRIM = 2,
-        V_PRIM     = 3
+        V_PRIM     = 3,
+        V_IDENTITY_CHANGE = 128
     } ViewType;
 
     class ViewId

--- a/gcomm/src/gmcast.cpp
+++ b/gcomm/src/gmcast.cpp
@@ -689,7 +689,7 @@ void gcomm::GMCast::handle_established(Proto* est)
 
     if (i != pending_addrs_.end())
     {
-        log_debug << "Erasing " << remote_addr << " from panding list";
+        log_debug << "Erasing " << remote_addr << " from pending list";
         pending_addrs_.erase(i);
     }
 
@@ -705,6 +705,16 @@ void gcomm::GMCast::handle_established(Proto* est)
         log_info << "remote endpoint " << est->remote_addr()
                  << " changed identity " << AddrList::value(i).uuid().full_str()
                  << " -> " << est->remote_uuid().full_str();
+
+        /* Inform upper protocol layers the new uuid will be used for
+           this node identification. */
+        gcomm::ViewId vid(V_IDENTITY_CHANGE);
+        View view(-1, vid);
+        view.add_joined(est->remote_uuid(), 0);
+        view.add_left(AddrList::value(i).uuid(), 0);
+        ProtoUpMeta meta(UUID::nil(), vid, &view);
+        send_up(Datagram(), meta);
+
         remote_addrs_.erase(i);
         i = remote_addrs_.insert_unique(
             make_pair(est->remote_addr(),

--- a/gcomm/src/pc_proto.cpp
+++ b/gcomm/src/pc_proto.cpp
@@ -147,6 +147,24 @@ std::ostream& gcomm::pc::operator<<(std::ostream& os, const gcomm::pc::Proto& p)
 //
 //
 
+void gcomm::pc::Proto::identity_changed(const gcomm::UUID& old_identity,
+                                        const gcomm::UUID& new_identity) {
+    NodeMap::iterator i, i_next;
+    for (i = instances_.begin(); i != instances_.end(); i = i_next)
+    {
+        i_next = i, ++i_next;
+        const UUID& uuid(NodeMap::key(i));
+
+        if (uuid == old_identity)
+        {
+            const Node sm_state(NodeMap::value(i));
+            instances_.erase(i);
+            instances_.insert_unique(std::make_pair(new_identity, sm_state));
+            log_info << "pc::Proto::identity_changed() " << old_identity << " -> " << new_identity;
+        }
+    }
+}
+
 void gcomm::pc::Proto::send_state()
 {
     log_debug << self_id() << " sending state";
@@ -653,6 +671,12 @@ void gcomm::pc::Proto::handle_reg(const View& view)
 
 void gcomm::pc::Proto::handle_view(const View& view)
 {
+    if (view.type() == V_IDENTITY_CHANGE) {
+        auto old_it = view.left().begin();
+        auto new_it = view.joined().begin();
+        identity_changed(NodeList::key(old_it), NodeList::key(new_it));
+        return;
+    }
 
     // We accept only EVS TRANS and REG views
     if (view.type() != V_TRANS && view.type() != V_REG)
@@ -705,7 +729,7 @@ int gcomm::pc::Proto::cluster_weight() const
     return total_weight;
 }
 
-// Validate state message agains local state
+// Validate state message against local state
 void gcomm::pc::Proto::validate_state_msgs() const
 {
     // #622, #638 Compute max TO seq among states from prim
@@ -1028,7 +1052,7 @@ void gcomm::pc::Proto::handle_state(const Message& msg, const UUID& source)
 
     // Early check for possibly conflicting primary components. The one
     // with greater view id may continue (as it probably has been around
-    // for longer timer). However, this should be configurable policy.
+    // for longer time). However, this should be configurable policy.
     if (prim() == true)
     {
         const Node& si(NodeMap::value(msg.node_map().find(source)));

--- a/gcomm/src/pc_proto.hpp
+++ b/gcomm/src/pc_proto.hpp
@@ -244,6 +244,8 @@ private:
     void handle_user(const Message&, const Datagram&,
                      const ProtoUpMeta&);
     void deliver_view(bool bootstrap = false);
+    void identity_changed(const gcomm::UUID& old_identity,
+                          const gcomm::UUID& new_identity);
 
     UUID   const      my_uuid_;       // Node uuid
     bool              start_prim_;    // Is allowed to start in prim comp

--- a/gcomm/src/view.cpp
+++ b/gcomm/src/view.cpp
@@ -57,6 +57,7 @@ static std::string to_string(const gcomm::ViewType type)
     case gcomm::V_REG:      return "REG";
     case gcomm::V_NON_PRIM: return "NON_PRIM";
     case gcomm::V_PRIM:     return "PRIM";
+    case gcomm::V_IDENTITY_CHANGE: return "IDENTITY_CHANGE";
     default:
         return "UNKNOWN";
         // gcomm_throw_fatal << "Invalid type value";
@@ -164,7 +165,7 @@ std::ostream& gcomm::operator<<(std::ostream& os, const gcomm::View& view)
 {
     os << "Current view of cluster as seen by this node\n";
     os << "view (";
-    if (view.is_empty() == true)
+    if (view.is_empty() == true && view.type() != V_IDENTITY_CHANGE)
     {
         os << "(empty)";
     }

--- a/gcomm/test/check_trace.hpp
+++ b/gcomm/test/check_trace.hpp
@@ -91,6 +91,8 @@ namespace gcomm
                     <<  " source view " << msg.source_view_id();
                 gcomm_assert(contains(msg.source()) == true);
                 break;
+            case V_IDENTITY_CHANGE:
+                break;
             case V_NONE:
                 gu_throw_fatal;
                 break;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4316

Problem:
If the node is partitioned from the cluster, and during this time it shuts down and starts again and then rejoins the cluster, the other part of the cluster still waits for partitioned node.

Cause:
Node's uuid is maintained in gvwstate.dat file. If the node shuts down gracefully, the file is deleted. When the node starts and there is no gvwstate.dat file, new uuid is assigned to this node. When such a node rejoins the cluster, it is identified by new uuid. gmcast layer properly detects that the node changed its identity, but this information is not propagated to upper protocol layers. pc layer maintains its own set of known nodes. As the information about identity changing is not delivered to this layer, it sees the "new" node identified by new uuid, but also waits for "old" node identified by old uuid.

Solution:
Propagate information about node's identity change to upper protocol layers.