### PR TITLE
PXC-4369: PXC 8.0.36 refresh - Q1 2024 (Disable appending zero-level

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -747,7 +747,8 @@ wsrep_status_t galera::ReplicatorSMM::replicate(TrxHandleMaster& trx,
     assert(trx.state() == TrxHandle::S_EXECUTING ||
            trx.state() == TrxHandle::S_MUST_ABORT);
 
-    if (trx.version() >= 6)
+    // Disable Zero level keys for TOI and NBO transactions.
+    if (trx.version() >= 6 && !(trx.flags() & TrxHandle::F_ISOLATION))
     {
         /* By default append zero-level key */
         galera::KeyData const k(trx.version());


### PR DESCRIPTION
certification keys for NBO and TOI transactions)

Analysis:

The zero-level keys introduced in commit 9439a735 conflicts with our implementation of NBO certification resulting in certification failure.

In our implementation, we perform NBO certification even for regular transactions and this makes even the non-conflicting transations to fail when there is an active NBO running in the cluster.

Fix:
Disable appending zero-level certification keys for NBO and TOI transactions.



Testing Done
----

[test_results.txt](https://github.com/percona/galera/files/14633238/test_results.txt)
