### PR TITLE
PXC-4369: PXC 8.0.36 refresh - Q1 2024 (Fix compilation errors on CentOS-7)

### DIFF
--- a/galerautils/tests/gu_asio_test.cpp
+++ b/galerautils/tests/gu_asio_test.cpp
@@ -961,7 +961,7 @@ static void throw_error(const char* msg)
 
 static EVP_PKEY* create_key()
 {
-#if OPENSSL_VERSION_MAJOR < 3
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     auto* bn = BN_new();
     if (!bn)
     {
@@ -993,7 +993,7 @@ static EVP_PKEY* create_key()
         throw_error("could not create RSA");
     }
     return ret;
-#endif /* OPENSSL_VERSION_MAJOR < 3 */
+#endif /* OPENSSL_VERSION_NUMBER < 0x30000000L */
 }
 
 static FILE* open_file(const std::string& path, const char* mode)
@@ -1024,6 +1024,7 @@ static void write_key(EVP_PKEY* pkey, const std::string& filename)
 static void set_x509v3_extensions(X509* x509, X509* issuer)
 {
     auto* conf_bio = BIO_new(BIO_s_mem());
+    char extn[] = "extensions";
     std::string ext{ "[extensions]\n"
                      "authorityKeyIdentifier=keyid,issuer\n"
                      "subjectKeyIdentifier=hash\n" };
@@ -1052,7 +1053,7 @@ static void set_x509v3_extensions(X509* x509, X509* issuer)
     X509V3_CTX ctx;
     X509V3_set_ctx(&ctx, issuer ? issuer : x509, x509, nullptr, nullptr, 0);
     X509V3_set_nconf(&ctx, conf);
-    if (!X509V3_EXT_add_nconf(conf, &ctx, "extensions", x509))
+    if (!X509V3_EXT_add_nconf(conf, &ctx, extn, x509))
     {
         throw_error("Could not add extension");
     }


### PR DESCRIPTION

https://perconadev.atlassian.net/browse/PXC-4369

***
Fixed the compilation errors on CentOS-7.

1. OPENSSL_VERSION_MAJOR is not defined in openssl 1.1.1, replaced it with OPENSSL_VERSION_NUMBER.
2. Fixed the error due to -Werror=write-strings

``` c++
/opt/percona-xtradb-cluster/percona-xtradb-cluster-galera/galerautils/tests/gu_asio_test.cpp:964:5: error: "OPENSSL_VERSION_MAJOR" is not defined, evaluates to 0 [-Werror=undef]
  964 | #if OPENSSL_VERSION_MAJOR < 3
      |     ^~~~~~~~~~~~~~~~~~~~~
/opt/percona-xtradb-cluster/percona-xtradb-cluster-galera/galerautils/tests/gu_asio_test.cpp: In function ‘void set_x509v3_extensions(X509*, X509*)’:
/opt/percona-xtradb-cluster/percona-xtradb-cluster-galera/galerautils/tests/gu_asio_test.cpp:1055:43: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
 1055 |     if (!X509V3_EXT_add_nconf(conf, &ctx, "extensions", x509))
      |                                           ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors

```