### PR TITLE
PXC-4428: Garbd terminates SST script's children after SST is complete

### DIFF
--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -45,6 +45,7 @@ Config::Config (int argc, char* argv[])
       log_     (),
       cfg_     (),
       recv_script_ (),
+      post_recv_script_(),
       workdir_ (),
 #if defined(WITH_COREDUMPER) && WITH_COREDUMPER
       coredumper_ (),
@@ -72,6 +73,7 @@ Config::Config (int argc, char* argv[])
         ("options,o",   po::value<std::string>(&options_),     "GCS/GCOMM option list")
         ("log,l",       po::value<std::string>(&log_),         "Log file")
         ("recv-script", po::value<std::string>(&recv_script_), "SST request receive script")
+        ("post-recv-script", po::value<std::string>(&post_recv_script_), "Post SST script")
         ("workdir,w",po::value<std::string>(&workdir_),
          "Daemon working directory")
         ;
@@ -152,6 +154,7 @@ Config::Config (int argc, char* argv[])
     strip_quotes(group_);
     strip_quotes(sst_);
     strip_quotes(recv_script_);
+    strip_quotes(post_recv_script_);
     strip_quotes(donor_);
     strip_quotes(options_);
     strip_quotes(log_);

--- a/garb/garb_config.hpp
+++ b/garb/garb_config.hpp
@@ -33,6 +33,7 @@ public:
 #endif
     bool               exit()    const { return exit_   ; }
     const std::string& recv_script() const { return recv_script_    ; }
+    const std::string& post_recv_script() const { return post_recv_script_    ; }
 
 private:
 
@@ -46,6 +47,7 @@ private:
     std::string log_;
     std::string cfg_;
     std::string recv_script_;
+    std::string post_recv_script_;
     std::string workdir_;
 #if defined(WITH_COREDUMPER) && WITH_COREDUMPER
     std::string coredumper_;

--- a/garb/garb_main.cpp
+++ b/garb/garb_main.cpp
@@ -218,7 +218,9 @@ main (int argc, char* argv[])
         }
 
         RecvLoop loop (config);
-        return loop.returnCode();
+        int rcode = loop.returnCode();
+        log_info << "Garbd returns " << rcode;
+        return rcode;
     }
     catch (std::exception& e)
     {

--- a/garb/garb_recv_loop.cpp
+++ b/garb/garb_recv_loop.cpp
@@ -20,11 +20,11 @@ signal_handler (int signum)
 }
 
 void
-RecvLoop::close_connection()
+RecvLoop::close_connection(bool explicit_close)
 {
     if (!closed_)
     {
-        gcs_.close();
+        gcs_.close(explicit_close);
         closed_ = true;
     }
 }
@@ -70,16 +70,18 @@ RecvLoop::RecvLoop (const Config& config)
                               << "SIGINT";
     }
 
-    process_ = std::make_shared<process>(config_.recv_script().c_str(), "rw", nullptr, false);
+    if(!config_.recv_script().empty()) {
+        process_ = std::make_shared<process>(config_.recv_script().c_str(), "rw", nullptr, false);
+    }
     loop();
 }
 
-void pipe_to_log(FILE* pipe) {
+void pipe_to_log(const char* log_prefix, FILE* pipe) {
     const int out_len = 1024;
     char out_buf[out_len];
     char* p;
     while ((p = fgets(out_buf, out_len, pipe)) != NULL) {
-        log_info << "[SST script] " << out_buf;
+        log_info << log_prefix << " " << out_buf;
     }
 }
 
@@ -127,25 +129,28 @@ RecvLoop::one_loop()
                 sst_requested_ = true;
                 auto sst_source_idx =  gcs_.request_state_transfer (config_.sst(),config_.donor());
                 sst_source_uuid_ = cc.memb[sst_source_idx].uuid_;
-                if(config_.recv_script().empty()) {
+                if(!process_) {
                     gcs_.join(gu::GTID(cc.uuid, cc.seqno), 0);
                 } else {
                     log_info << "Starting SST script";
                     process_->execute("rw", NULL);
 
-                     std::thread err_log_thd([&](){
-                        pipe_to_log(process_->err_pipe());
-                        log_info << "SST script ended";
+                    std::thread err_log_thd([&](){
+                        pipe_to_log("[SST script]", process_->err_pipe());
+                        log_info << "SST script ended "
+                                 << (sst_terminated_ ? "by termination" : "gracefully");
                         sst_ended_ = true;
-                        gcs_.close(true);
+                        script_end_cv_.notify_all();
+                        close_connection(true);
                     });
                     sst_err_log_.swap(err_log_thd);
 
                     std::thread out_log_thd([&](){
-                        pipe_to_log(process_->pipe());
+                        pipe_to_log("[SST script]", process_->pipe());
                     });
                     sst_out_log_.swap(out_log_thd);
 
+                    // monitor Donor's state
                     std::thread sst_status_thd([&](){
                         while(sst_status_keep_running_) {
 
@@ -156,12 +161,51 @@ RecvLoop::one_loop()
                                 process_->terminate();
                                 break;
                             } else if(st != GCS_NODE_STATE_DONOR) {
-                                // The donor is going back to SYNCED. If SST streaming didn't start yet,
-                                // it won't.
-                                // Send SIGTERM to the script and let it handle this situation.
-                                log_info << "Donor no longer in donor state, interrupting script";
-                                sst_terminated_ = true;
-                                process_->terminate();
+                                // The donor is going back to SYNCED.
+                                // It can be one of the following case:
+                                // 1. SST hasn't even started, so script is most probably still
+                                //    waiting in TCP connection
+                                // 2. SST finished, script received data
+                                // Because of the socat problem, if we end up in case 1, we have to
+                                // send kill to the whole group (script and its children) to avoid
+                                // socat hanging forever and blocking ports for next requests.
+                                // In case 1 we should simply wait for script to finish.
+                                // Unfortunately from garbd point of view it is not trivial to distinguish
+                                // these two cases. That's why we always terminate the whole group
+                                // just after receiving sst.
+                                // If any post-processing of received SST has to be done, it should be done
+                                // in post-sst-script.
+                                //
+                                // Having said that, we will end up in 'if (sst_terminated_)' or
+                                // 'else if(sst_ended_)' branch below randomly, (race between err_log_thd
+                                // and sst_status_thd which is not good in general, but it is as it is.
+
+                                // Because of the above, we will introduce a little ugly hack here.
+                                // After successful SST Donor exits from 'donor' state immediately.
+                                // That means we've got a race condition between err_log_thd and sst_status_thd.
+                                // Whatever happens first:
+                                // 1. script exits and we catch it in err_log_thd
+                                // 2. Donor exits from 'donor' state and we catch it in sst_status_thd
+                                // we will either wait for script to finish or terminate it with pgkill
+                                // There is no easy and reliable way to synchronize it, because from garbd point
+                                // of view we don't have the information about SST success/failure when handling
+                                // event of Donor moving from 'donor' state.
+                                // The hack is to wait 'a bit' to let sst-script to finish gracefully and then decide
+                                // if we still need to kill it or not.
+                                // It is up to SST script to exit immediately after receiving SST.
+                                // If any post processing has to be done it has to be done in post-sst-script.
+
+                                // Wait up to 5 seconds for recv-script to finish
+                                std::unique_lock<std::mutex> lock(script_end_mtx_);
+                                script_end_cv_.wait_for(lock, std::chrono::seconds(5));
+
+                                if (sst_ended_) {
+                                    log_info << "Donor no longer in donor state, sst-script finished.";
+                                } else {
+                                    log_info << "Donor no longer in donor state, but sst-script hasn't finish. Interrupting script.";
+                                    sst_terminated_ = true;
+                                    process_->terminate();
+                                }
                                 break;
                             }
                             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -177,7 +221,9 @@ RecvLoop::one_loop()
         {
             if (cc.memb.size() == 0) // SELF-LEAVE after closing connection
             {
-                if(!config_.recv_script().empty()) {
+                if(process_) {
+                    // Note that in case of termination, both sst_terminated_ and
+                    // sst_ended_ flags are set. We need to test sst_terminated_ first.
                     if (sst_terminated_) {
                         log_info << "SST script already terminated";
                         rcode_ = process_->wait();
@@ -185,6 +231,7 @@ RecvLoop::one_loop()
                         sst_out_log_.join();
                         sst_status_keep_running_ = false;
                         sst_status_thread_.join();
+                        rcode_ = 1;
                         log_info << "Exiting main loop";
                         return true;
                     } else if(sst_ended_) {
@@ -192,11 +239,32 @@ RecvLoop::one_loop()
                         // standard output. We wait for it to exit and return its error code.
                         log_info << "Waiting for SST script to stop";
                         rcode_ = process_->wait();
-                        log_info << "SST script stopped";
+                        log_info << "SST script stopped with exit code: " << rcode_;
                         sst_err_log_.join();
                         sst_out_log_.join();
                         sst_status_keep_running_ = false;
                         sst_status_thread_.join();
+
+                        if(rcode_ == 0 && !config_.post_recv_script().empty()) {
+                            log_info << "Running post-recv-script";
+                            process post_sst_process(config_.post_recv_script().c_str(), "rw", nullptr);
+
+                            // grab stdout and stderr from post-recv-script
+                            std::thread post_sst_process_err_log_thd([&](){
+                                pipe_to_log("[post-SST script]", post_sst_process.err_pipe());
+                            });
+
+                            std::thread post_sst_process_err_log_thd_out_log_thd([&](){
+                                pipe_to_log("[post-SST script]", post_sst_process.pipe());
+                            });
+
+                            rcode_ = post_sst_process.wait();
+                            post_sst_process_err_log_thd.join();
+                            post_sst_process_err_log_thd_out_log_thd.join();
+
+                            log_info << "post-recv-script finished with exit code: " << rcode_;
+                        }
+
                         log_info << "Exiting main loop";
                         return true;
                     } else {
@@ -206,6 +274,7 @@ RecvLoop::one_loop()
                         // connection, we terminate it and report an error.
                         log_info << "Terminating SST script";
                         process_->terminate();
+                        sst_terminated_ = true;
                         sst_err_log_.join();
                         sst_out_log_.join();
                         sst_status_keep_running_ = false;
@@ -227,9 +296,8 @@ RecvLoop::one_loop()
         if (config_.sst() != Config::DEFAULT_SST)
         {
             // we requested custom SST, so we're done here
-            if(config_.recv_script().empty() && !closed_) {
-                gcs_.close(true);
-                closed_ = true;
+            if(!process_) {
+                close_connection(true);
             }
         }
 

--- a/garb/garb_recv_loop.hpp
+++ b/garb/garb_recv_loop.hpp
@@ -13,6 +13,8 @@
 #include <memory>
 #include <thread>
 #include <atomic>
+#include <mutex>
+#include <condition_variable>
 
 #include <pthread.h>
 
@@ -35,7 +37,7 @@ private:
 
     bool one_loop();
     void loop();
-    void close_connection();
+    void close_connection(bool explicit_close = false);
 
     const Config& config_;
     gu::Config    gconf_;
@@ -75,16 +77,15 @@ private:
     gu_uuid_t sst_source_uuid_;
     bool sst_requested_;
     std::atomic_bool sst_status_keep_running_;
-    bool sst_ended_;
-    bool sst_terminated_;
+    std::atomic_bool sst_ended_;
+    std::atomic_bool sst_terminated_;
 
     std::shared_ptr<process> process_;
     std::thread sst_out_log_;
     std::thread sst_err_log_;
     std::thread sst_status_thread_;
-
-
-
+    std::mutex script_end_mtx_;
+    std:: condition_variable script_end_cv_;
 }; /* RecvLoop */
 
 } /* namespace garb */


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4428

Problem:
garbd terminates recv-script immediately after Donor moves from 'donor' state after serving SST. As the result, if there are any post-receive actions in recv-script they are not executed (or may be terminated in the middle)

Cause:
garbd monitors script's error output and when the pipe is closed, it considers script as finished (err_log_thd). At the same time garbd monitors the state of the donor with 1 second frequency (sst_status_thd) The idea is that if script exits after SST, the exit will be detected by err_log_thd, and sst_status_thd will be stopped. On the other hand, if recv-script hangs, and Donor exits 'donor' state, such situation will be detected by sst_status_thd, and script will be killed. Killing of script will be detected by err_log_thd. The problem is, that there is no way to tell sst_status_thd that scrit received data and there is more time needed. The logic is simple: if Donor exited 'donor' state and the script is still running - kill the script.

Solution:
1. After detection of Donor exiting 'donor' state, wait for at most 5 seconds for recv-script to finish. In most cases, this will be immediate action. If the script doesn't exit in 5 seconds, kill it and consider SST to be failed.
2. Introduced post-recv-script optional parameter. Any post-download actions should be done here. The script is executed only if recv-script finished with success (exit 0, was not terminated)