### PR TITLE
Fixed compilation with g++ 13

### DIFF
--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -2359,7 +2359,7 @@ gcs_group_fetch_pfs_info(
         strncpy(entries[i].host_name, node.name, WSREP_HOSTNAME_LENGTH);
         entries[i].host_name[WSREP_HOSTNAME_LENGTH] = 0;
 
-        strncpy(entries[i].uuid, node.id, WSREP_UUID_STR_LEN);
+        memcpy(entries[i].uuid, node.id, WSREP_UUID_STR_LEN);
         entries[i].uuid[WSREP_UUID_STR_LEN] = 0;
 
         strncpy(


### PR DESCRIPTION
error: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' output may be truncated copying 36 bytes from a string of length 36 [-Werror=stringop-truncation]