### PR TITLE
PXC-4453: Flow control flapping hangs the cluster

### DIFF
--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -519,18 +519,20 @@ static inline bool
 gcs_fc_stop_begin (gcs_conn_t* conn)
 {
     long err = 0;
-
-    bool ret = (conn->stop_count <= 0                                     &&
+    bool ret = (!(err = gu_mutex_lock (&conn->fc_lock))                   &&
+                conn->stop_count <= 0                                     &&
                 conn->stop_sent_ <= 0                                     &&
                 conn->queue_len  >  (conn->upper_limit + conn->fc_offset) &&
-                conn->state      <= conn->max_fc_state                    &&
-                !(err = gu_mutex_lock (&conn->fc_lock)));
+                conn->state      <= conn->max_fc_state);
 
     if (gu_unlikely(err)) {
             gu_fatal ("Mutex lock failed: %d (%s)", err, strerror(err));
             abort();
     }
 
+    if (!ret) {
+        gu_mutex_unlock(&conn->fc_lock);
+    }
     return ret;
 }
 
@@ -552,11 +554,20 @@ gcs_fc_stop_end (gcs_conn_t* conn)
     if (conn->stop_sent() <= 0)
     {
         conn->stop_sent_inc(1);
-        gu_mutex_unlock (&conn->fc_lock);
+
+        /*
+          We need to serialize gcs_recv_thread and wsrep_replication_thread here.
+          Let's say we decided above to send STOP, incremented stop_sent and released fc_lock
+          and didn't get to gcs_send_fc_event() yet.
+          Now wsrep_replication_thread processes gcs_fc_cont_end, where it check for stop_sent > 0
+          decrements it, releases fc_lock and sends CONT. It goes first in the queue, then we
+          continue here and STOP goes to the queue.
+          As the messages are swapped, the STOP has no corresponding CONT following and nodes
+          stuck waiting for CONT.
+        */
 
         ret = gcs_send_fc_event (conn, GCS_FC_STOP);
 
-        gu_mutex_lock (&conn->fc_lock);
         if (ret >= 0) {
             ret = 0;
             conn->stats_fc_stop_sent++;
@@ -591,16 +602,19 @@ gcs_fc_cont_begin (gcs_conn_t* conn)
     bool queue_decreased = (conn->fc_offset > conn->queue_len &&
                             (conn->fc_offset = conn->queue_len, true));
 
-    bool ret = (conn->stop_sent_  >  0                                    &&
+    bool ret = (!(err = gu_mutex_lock (&conn->fc_lock))                   &&
+                conn->stop_sent_  >  0                                    &&
                 (conn->lower_limit >= conn->queue_len || queue_decreased) &&
-                conn->state        <= conn->max_fc_state                  &&
-                !(err = gu_mutex_lock (&conn->fc_lock)));
+                conn->state        <= conn->max_fc_state);
 
     if (gu_unlikely(err)) {
         gu_fatal ("Mutex lock failed: %d (%s)", err, strerror(err));
         abort();
     }
 
+    if (!ret) {
+        gu_mutex_unlock(&conn->fc_lock);
+    }
     return ret;
 }
 
@@ -620,11 +634,9 @@ gcs_fc_cont_end (gcs_conn_t* conn)
     if (conn->stop_sent())
     {
         conn->stop_sent_dec(1);
-        gu_mutex_unlock (&conn->fc_lock);
 
         ret = gcs_send_fc_event (conn, GCS_FC_CONT);
 
-        gu_mutex_lock (&conn->fc_lock);
         if (gu_likely (ret >= 0)) {
             ret = 0;
             conn->stats_fc_cont_sent++;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4453

Problem:
When flow control (FC) message is sent by node it may end up with whole cluster stuck.

Cause:
FC activation is being triggered from gcs_recv_thread level. When the message is recevied from foreign node, the local node checks the lengths of recv_q. If it is above the limit, the node sends FC-start message to whole cluster. Then the same node is responsible for sending FC-stop to let other nodes know that they can send more messages.

FC deactivation is being triggered from wsrep_replication_thread level. Again, if the level of recv_q is below the threashold, and FC-start message was sent, the node sends FC-stop mesage to the cluster.

The problem is that both threads are not synchronized when sending FC message to the cluster. So it may happen that gcs_recv_thread detects that FC-start has to be sent, it internally marks this action, but don't send message yet. At the same time wsrep_replication_thread consumes messages from recv_q and detects that FC-start was signalled as sent. So it sends FC-stop to the channel. Then gcs_recv_thread continues and sends FC-stop. All nodes are blocked.

Another possible scenario is that gcs_recv_thread detects that FC-start should be sent, but don't mark this fact yet. wsrep_recv_thread consumes the whole recv_q. Then gcs_recv_thread sends FC-start to the channel. All nodes stop sending messages, recv_q is empty, there is no one to trigger FC-stop

Solution:
Prevent swapping of FC-start / FC-stop messages by having FC part locked for the whole time from the detection if action should be taken up to the time when the FC message is already sent.