### PR TITLE
PXC-4435: PXC 8.4.0 refresh - Q2 2024

### DIFF
--- a/garb/garb_gcs.cpp
+++ b/garb/garb_gcs.cpp
@@ -123,7 +123,7 @@ Gcs::request_state_transfer (const std::string& request,
     {
         log_fatal << "State transfer request failed: " << ret
                   << " (" << strerror(-ret) << ")";
-        gu_throw_error(-ret) << "State transfer request failed";
+        gu_throw_system_error(-ret) << "State transfer request failed";
     }
 
     return ret;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4435

Fixed error returned by garbd (MTR)
After f12ff7e6ff7899c2261ce8c1df864dcec1855d33, detailed error code and reason are not available.