### PR TITLE
PXC-4463: PXC 8.0.39 refresh - Q3 2024

### DIFF
--- a/galerautils/src/gu_pfs.cpp
+++ b/galerautils/src/gu_pfs.cpp
@@ -23,7 +23,6 @@ static void dummy_pfs_cb(wsrep_pfs_instr_type_t type, wsrep_pfs_instr_ops_t ops,
     switch (ops) {
       case WSREP_PFS_INSTR_OPS_INIT: {
         gu_mutex_t *mutex = new gu_mutex_t();
-       //  fprintf(stderr, "KH: WSREP_PFS_INSTR_OPS_INIT x%llX\n", (unsigned long long)mutex);
         gu_mutex_init (mutex, nullptr);
         *value = mutex;
 
@@ -34,7 +33,6 @@ static void dummy_pfs_cb(wsrep_pfs_instr_type_t type, wsrep_pfs_instr_ops_t ops,
         gu_mutex_t *mutex = reinterpret_cast<gu_mutex_t *>(*value);
         assert(mutex != nullptr);
 
-        // fprintf(stderr, "KH: WSREP_PFS_INSTR_OPS_DESTROY x%llX\n", (unsigned long long)mutex);
         gu_mutex_destroy (mutex);
         delete mutex;
         *value = nullptr;
@@ -159,7 +157,6 @@ static void dummy_pfs_cb(wsrep_pfs_instr_type_t type, wsrep_pfs_instr_ops_t ops,
 gu_pfs_instr_cb_t pfs_instr_callback = dummy_pfs_cb;
 int gu_conf_set_pfs_instr_callback (gu_pfs_instr_cb_t callback)
 {
-  // fprintf(stderr, "KH: setting callback to: x%llX\n", (unsigned long long)callback);
   if (callback != nullptr) {
     pfs_instr_callback = callback;
   } else {

--- a/galerautils/src/gu_threads.c
+++ b/galerautils/src/gu_threads.c
@@ -14,15 +14,6 @@
 #include <errno.h>
 #include <string.h> // strerror()
 
-#ifdef PXC
-/* register callback for PFS instrumentation */
-gu_pfs_instr_cb_t pfs_instr_callback = NULL;
-int gu_conf_set_pfs_instr_callback (gu_pfs_instr_cb_t callback)
-{
-  pfs_instr_callback = callback;
-  return 0;
-}
-#endif /* PXC */
 
 #ifdef GU_DEBUG_MUTEX
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4463

Post push fix.

Intention of the commit ec06c3bf was moving
gu_conf_set_pfs_instr_callback() from gu_threads.c to new gu_pfs.cpp. However, it was not removed from gu_threads.c. The result was that we had gu_conf_set_pfs_instr_callback() in two places.

When cmake is used to build galera.so, we build two static libraries first (libgalerautilsxx.a and libgalerautils.a) and then link to galera.so. Both contain gu_conf_set_pfs_instr_callback(), but as they are *.a files, the linker uses the version from the 1st one, ignoring duplicates.
Scons compiles all translation units to *.o files and then link them directly to galera.so. This time gu_pfs.os and gu_threads.os both contain gu_conf_set_pfs_instr_callback(). Linker detects violation of ODR rule and complains.

Solution:
Removed gu_conf_set_pfs_instr_callback() from gu_threads.c