### PR TITLE
PXC-4645: Provide a way to distinguish SST failure cases in garbd

### DIFF
--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -46,8 +46,10 @@ Config::Config (int argc, char* argv[])
       log_     (),
       cfg_     (),
       recv_script_ (),
+      wait_for_recv_script_exit_(false),
       post_recv_script_(),
       workdir_ (),
+      extended_exit_codes_(false),
 #if defined(WITH_COREDUMPER) && WITH_COREDUMPER
       coredumper_ (),
 #endif
@@ -75,6 +77,8 @@ Config::Config (int argc, char* argv[])
         ("log,l",       po::value<std::string>(&log_),         "Log file")
         ("recv-script", po::value<std::string>(&recv_script_), "SST request receive script")
         ("post-recv-script", po::value<std::string>(&post_recv_script_), "Post SST script")
+        ("wait-for-recv-script-exit", "Wait for recv-script graceful exit (don't kill it after transfer).")
+        ("extended-exit-codes", "Report extended exit codes")
         ("workdir,w",po::value<std::string>(&workdir_),
          "Daemon working directory")
         ;
@@ -150,6 +154,13 @@ Config::Config (int argc, char* argv[])
     if (vm.count("daemon"))
     {
         daemon_ = true;
+    }
+
+    if (vm.count("wait-for-recv-script-exit")) {
+        wait_for_recv_script_exit_ = true;
+    }
+    if (vm.count("extended-exit-codes")) {
+        extended_exit_codes_ = true;
     }
 
     /* Seeing how https://svn.boost.org/trac/boost/ticket/850 is fixed long and

--- a/garb/garb_config.hpp
+++ b/garb/garb_config.hpp
@@ -28,11 +28,13 @@ public:
     const std::string& cfg()     const { return cfg_    ; }
     const std::string& log()     const { return log_    ; }
     const std::string& workdir() const { return workdir_; }
+    bool  extended_exit_codes() const { return extended_exit_codes_; }
 #if defined(WITH_COREDUMPER) && WITH_COREDUMPER
     const std::string& coredumper() const { return coredumper_; }
 #endif
     bool               exit()    const { return exit_   ; }
     const std::string& recv_script() const { return recv_script_    ; }
+    bool               wait_for_recv_script_exit() const { return wait_for_recv_script_exit_; }
     const std::string& post_recv_script() const { return post_recv_script_    ; }
 
 private:
@@ -47,8 +49,10 @@ private:
     std::string log_;
     std::string cfg_;
     std::string recv_script_;
+    bool        wait_for_recv_script_exit_;
     std::string post_recv_script_;
     std::string workdir_;
+    bool        extended_exit_codes_;
 #if defined(WITH_COREDUMPER) && WITH_COREDUMPER
     std::string coredumper_;
 #endif

--- a/garb/garb_recv_loop.cpp
+++ b/garb/garb_recv_loop.cpp
@@ -19,6 +19,21 @@ signal_handler (int signum)
     global_gcs->close();
 }
 
+std::string
+RecvLoop::rc_to_string(int c) {
+    if (c == return_code::OK) return "OK";
+    if (c == return_code::DONOR_DISAPPEARED) return "DONOR_DISAPPEARED";
+    if (c == return_code::SST_REQUEST_FAILURE) return "SST_REQUEST_FAILURE";
+    if (c == return_code::SST_SCRIPT_TERMINATED) return "SST_SCRIPT_TERMINATED";
+    if (c == return_code::GENERIC_FAILURE) return "GENERIC_FAILURE";
+    return std::to_string(c);
+}
+
+int RecvLoop::return_code(int basic, int extended) {
+    return config_.extended_exit_codes() ? extended : basic;
+}
+
+
 void
 RecvLoop::close_connection(bool explicit_close)
 {
@@ -159,54 +174,65 @@ RecvLoop::one_loop()
                             auto st = gcs_.state_for(sst_source_uuid_);
                             if(st == GCS_NODE_STATE_MAX) {
                                 log_info << "Donor is no longer in the cluster, interrupting script";
+                                rcode_ = return_code(1, return_code::DONOR_DISAPPEARED);
                                 sst_terminated_ = true;
                                 process_->terminate();
                                 break;
                             } else if(st != GCS_NODE_STATE_DONOR) {
-                                // The donor is going back to SYNCED.
-                                // It can be one of the following case:
-                                // 1. SST hasn't even started, so script is most probably still
-                                //    waiting in TCP connection
-                                // 2. SST finished, script received data
-                                // Because of the socat problem, if we end up in case 1, we have to
-                                // send kill to the whole group (script and its children) to avoid
-                                // socat hanging forever and blocking ports for next requests.
-                                // In case 1 we should simply wait for script to finish.
-                                // Unfortunately from garbd point of view it is not trivial to distinguish
-                                // these two cases. That's why we always terminate the whole group
-                                // just after receiving sst.
-                                // If any post-processing of received SST has to be done, it should be done
-                                // in post-sst-script.
-                                //
-                                // Having said that, we will end up in 'if (sst_terminated_)' or
-                                // 'else if(sst_ended_)' branch below randomly, (race between err_log_thd
-                                // and sst_status_thd which is not good in general, but it is as it is.
-
-                                // Because of the above, we will introduce a little ugly hack here.
-                                // After successful SST Donor exits from 'donor' state immediately.
-                                // That means we've got a race condition between err_log_thd and sst_status_thd.
-                                // Whatever happens first:
-                                // 1. script exits and we catch it in err_log_thd
-                                // 2. Donor exits from 'donor' state and we catch it in sst_status_thd
-                                // we will either wait for script to finish or terminate it with pgkill
-                                // There is no easy and reliable way to synchronize it, because from garbd point
-                                // of view we don't have the information about SST success/failure when handling
-                                // event of Donor moving from 'donor' state.
-                                // The hack is to wait 'a bit' to let sst-script to finish gracefully and then decide
-                                // if we still need to kill it or not.
-                                // It is up to SST script to exit immediately after receiving SST.
-                                // If any post processing has to be done it has to be done in post-sst-script.
-
-                                // Wait up to 5 seconds for recv-script to finish
-                                std::unique_lock<std::mutex> lock(script_end_mtx_);
-                                script_end_cv_.wait_for(lock, std::chrono::seconds(5));
-
-                                if (sst_ended_) {
-                                    log_info << "Donor no longer in donor state, sst-script finished.";
+                                if (config_.wait_for_recv_script_exit()) {
+                                    // The donor is going back to SYNCED, but
+                                    // we are asked to wait for recv-script to finish.
+                                    // It is up to the recv-script to handle all timeouts, etc...
+                                    // If it is stuck, garbd will wait infinitely.
+                                    rcode_ = process_->wait();
+                                    log_info << "sst-script finished with code (wait): " << rcode_;
                                 } else {
-                                    log_info << "Donor no longer in donor state, but sst-script hasn't finish. Interrupting script.";
-                                    sst_terminated_ = true;
-                                    process_->terminate();
+                                    // The donor is going back to SYNCED.
+                                    // It can be one of the following case:
+                                    // 1. SST hasn't even started, so script is most probably still
+                                    //    waiting in TCP connection
+                                    // 2. SST finished, script received data
+                                    // Because of the socat problem, if we end up in case 1, we have to
+                                    // send kill to the whole group (script and its children) to avoid
+                                    // socat hanging forever and blocking ports for next requests.
+                                    // In case 2 we should simply wait for script to finish.
+                                    // Unfortunately from garbd point of view it is not trivial to distinguish
+                                    // these two cases. That's why we always terminate the whole group
+                                    // just after receiving sst.
+                                    // If any post-processing of received SST has to be done, it should be done
+                                    // in post-sst-script.
+                                    //
+                                    // Having said that, we will end up in 'if (sst_terminated_)' or
+                                    // 'else if(sst_ended_)' branch below randomly, (race between err_log_thd
+                                    // and sst_status_thd which is not good in general, but it is as it is.
+
+                                    // Because of the above, we will introduce a little ugly hack here.
+                                    // After successful SST Donor exits from 'donor' state immediately.
+                                    // That means we've got a race condition between err_log_thd and sst_status_thd.
+                                    // Whatever happens first:
+                                    // 1. script exits and we catch it in err_log_thd
+                                    // 2. Donor exits from 'donor' state and we catch it in sst_status_thd
+                                    // we will either wait for script to finish or terminate it with pgkill
+                                    // There is no easy and reliable way to synchronize it, because from garbd point
+                                    // of view we don't have the information about SST success/failure when handling
+                                    // event of Donor moving from 'donor' state.
+                                    // The hack is to wait 'a bit' to let sst-script to finish gracefully and then decide
+                                    // if we still need to kill it or not.
+                                    // It is up to SST script to exit immediately after receiving SST.
+                                    // If any post processing has to be done it has to be done in post-sst-script.
+                                    // Wait up to 5 seconds for recv-script to finish
+                                    std::unique_lock<std::mutex> lock(script_end_mtx_);
+                                    script_end_cv_.wait_for(lock, std::chrono::seconds(5));
+
+                                    if (sst_ended_) {
+                                        log_info << "Donor no longer in donor state, sst-script finished with code (nowait): " << rcode_;
+                                        // rcode_ was resolved basing on script's exit code and post-sst script's exit code
+                                    } else {
+                                        log_info << "Donor no longer in donor state, but sst-script hasn't finish. Interrupting script.";
+                                        rcode_ = return_code(1, return_code::SST_SCRIPT_TERMINATED);
+                                        sst_terminated_ = true;
+                                        process_->terminate();
+                                    }
                                 }
                                 break;
                             }
@@ -227,21 +253,30 @@ RecvLoop::one_loop()
                     // Note that in case of termination, both sst_terminated_ and
                     // sst_ended_ flags are set. We need to test sst_terminated_ first.
                     if (sst_terminated_) {
-                        log_info << "SST script already terminated";
-                        rcode_ = process_->wait();
+                        // Donor exited in the middle of transfer
+                        // or garbd had to terminate sst script after the transfer (sst script didn't self-exited)
+                        log_info << "SST script has been terminated";
+                        process_->wait();
                         sst_err_log_.join();
                         sst_out_log_.join();
                         sst_status_keep_running_ = false;
                         sst_status_thread_.join();
-                        rcode_ = 1;
-                        log_info << "Exiting main loop";
+                        log_info << "Exiting main loop with code " << rc_to_string(rcode_);
                         return true;
                     } else if(sst_ended_) {
                         // Good path: we decided to close the connection after the receiver script closed its
                         // standard output. We wait for it to exit and return its error code.
-                        log_info << "Waiting for SST script to stop";
-                        rcode_ = process_->wait();
-                        log_info << "SST script stopped with exit code: " << rcode_;
+                        // In case when config_.wait_for_recv_script_exit() == false, we are not asked to wait
+                        // for sst script finish. If we are here, it means that the script finished
+                        // but we still need to get its exit code.
+                        // On the other hand, if wait_for_recv_script_exit() == true, we already waited
+                        // when we detected that donor moved back to synced state. At that time we already
+                        // collected exit code of the script.
+                        if (process_->waitable()) {
+                            log_info << "Waiting for SST script to finish";
+                            rcode_ = process_->wait();
+                            log_info << "SST script finished with exit code: " << rcode_;
+                        }
                         sst_err_log_.join();
                         sst_out_log_.join();
                         sst_status_keep_running_ = false;
@@ -267,7 +302,7 @@ RecvLoop::one_loop()
                             log_info << "post-recv-script finished with exit code: " << rcode_;
                         }
 
-                        log_info << "Exiting main loop";
+                        log_info << "Exiting main loop with code " << rc_to_string(rcode_);
                         return true;
                     } else {
                         // Error path: we are closing the connection because there is an SST error,
@@ -281,13 +316,14 @@ RecvLoop::one_loop()
                         sst_out_log_.join();
                         sst_status_keep_running_ = false;
                         sst_status_thread_.join();
-                        log_info << "Exiting main loop";
-                        rcode_ = 1;
+                        rcode_ = return_code(1, return_code::SST_REQUEST_FAILURE);
+                        log_info << "Exiting main loop with code " << rc_to_string(rcode_);
                         return true;
                     }
                 } else {
-                        log_info << "Exiting main loop";
-                        rcode_ = 0;
+                        // no custom SST script
+                        rcode_ = return_code::OK;
+                        log_info << "Exiting main loop with code " << rc_to_string(rcode_);
                         return true;
                 }
             }
@@ -341,7 +377,7 @@ RecvLoop::loop()
         {
             log_error << e.what();
             close_connection();
-            rcode_ = 1;
+            rcode_ = return_code(1, return_code::GENERIC_FAILURE);
             switch (e.get_errno())
             {
                 case -GCS_CLOSED_ERROR:

--- a/garb/garb_recv_loop.hpp
+++ b/garb/garb_recv_loop.hpp
@@ -23,6 +23,37 @@ class process;
 namespace garb
 {
 
+// Do not change exit codes as they are visible to garbd's outside world.
+namespace return_code {
+    /* Generic */
+    const int OK = 0;
+
+    /* codes 1 - 34 can be returned by OS if there is a problem with recv-script
+       or post-recv-script (permissions, non-existing file, etc).
+       Let's allocate codes 100 - 199 for garbd */
+    const int GARBD_EXIT_CODE_BASE = 100;
+
+    const int GENERIC_FAILURE = GARBD_EXIT_CODE_BASE;
+
+    /* The following codes are returned only if 'recv-script' is specified.
+       If the recv-script finishes without being terminated by garbd
+       its exit code is returned.
+       It is up to the script to use exit codes that are not in collision
+       with garbd exit codes. */
+
+    /* Donor was accessible, but it disappeared in the middle of SST transfer */
+    const int DONOR_DISAPPEARED = GARBD_EXIT_CODE_BASE + 1;
+    /* Wrong request, eg. nonexisting donor SST script specified. */
+    const int SST_REQUEST_FAILURE = GARBD_EXIT_CODE_BASE + 2;
+    /* recv-script didn't finish in 5 seconds after the donor transitioned from
+       DONOR state back to SYNC state. Garbd killed the script.
+       (possible only if garbd started without --wait-for-recv-script-exit) */
+    const int SST_SCRIPT_TERMINATED = GARBD_EXIT_CODE_BASE + 3;
+
+    /* Reserved 99 exit codes. recv-script should use exit codes 0 or > GARBD_EXIT_CODE_LAST*/
+    const int GARBD_EXIT_CODE_LAST = GARBD_EXIT_CODE_BASE + 99;
+}
+
 class RecvLoop
 {
 public:
@@ -38,6 +69,8 @@ private:
     bool one_loop();
     void loop();
     void close_connection(bool explicit_close = false);
+    std::string rc_to_string(int rc);
+    int return_code(int basic, int extended);
 
     const Config& config_;
     gu::Config    gconf_;

--- a/garb/process.h
+++ b/garb/process.h
@@ -86,6 +86,7 @@ class process {
   const char *cmd() { return str_; }
   void terminate();
   void interrupt();
+  bool waitable() { return (pid_ != 0); }
 };
 
 #endif /* PROCASS_H */


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4645

Problem:
In case of almoste any failure, garbd exit code is 1.

Solution:
Extended set or exit codes returned by garbd. Extended exit codes are returned only if --extended-exit-codes command line parameter is specified. Otherwise the legacy behavior applies.

Additonally introduced --wait-for-recv-script-exit flag. If specified, garbd will wait for recv-script to finish. In other words it won't kill it when the donor's state is shifted back to SYNC. It is script's responsibility to handle all possible hangs, timeouts, etc. If it hangs, garbd will wait for its exit infinitely. If the flag is not specified, garbd kills the script 5 seconds after donor shift back to SYNC in case script does not exits (legacy behavior).