### PR TITLE
PXC-4682: Processing event queue:... -nan% displayed during IST

### DIFF
--- a/galerautils/src/gu_progress.hpp
+++ b/galerautils/src/gu_progress.hpp
@@ -49,9 +49,11 @@ namespace gu
 
         void log(gu::datetime::Date const now)
         {
+            double percent
+                = (total_ > 0) ? (double(current_) / total_ * 100.0) : 0.0;
             log_info << prefix_ << "... "
                      << std::fixed << std::setprecision(1)
-                     << (double(current_)/total_ * 100) << "% ("
+                     << percent << "% ("
                      << current_ << '/' << total_
                      << units_ << ") complete.";
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4682

Problem:
Joiner prints Processing event queue:... -nan% (0/0 events) complete during IST.

Cause:
Let's consider 2-nodes cluster. Joiner joins the cluster, receives N IST events and starts applying them. If there is ongoing write workload on the Donor, new writesets are replicated and buffered on Joiner side to be applied after applying IST events.
When Joiner finishes with IST events, it starts applying buffered events. This is where from the problematic log comes from. If there was no write workload on the Donor side during IST events applying, nothing is buffered on Joiner side. We use recv_q fifo length to initialize Progress object. As there are no items in the queue, the initialization value is 0, which results in 0/0 => nan. Then the Progress object is updated upon receiving JOIN action (items count is incremented by 1), that's why at the completion of event queue processing we see n+1/n+1 (in problematic case 1/1) events.

Solution:
Handle the case when we are dividing by 0.