### PR TITLE
PXC-4845: Node remains up and running after IST failure, causing othe…

### DIFF
--- a/galera/src/ist.cpp
+++ b/galera/src/ist.cpp
@@ -557,6 +557,13 @@ void galera::ist::Receiver::run()
                 assert(!progress);
                 if (act.seqno_g > first_seqno_)
                 {
+                    /* MTR test needs to execute some workload on the Donor node while waiting here.
+                    Unfortunately the server is not ready for connections yet, so we can't use GU_DBUG_SYNC_WAIT()
+                    to do the job and then unblock the joiner. */
+                    GU_DBUG_SYNC_EXECUTE("ist_receiver_wait_afterreceived_wrong_starting_seqno", {
+                        sleep(15);
+                    });
+
                     error_os << "IST started with wrong seqno: " << act.seqno_g
                              << ", expected <= " << first_seqno_;
                     ec = EINVAL;

--- a/galera/src/ist.hpp
+++ b/galera/src/ist.hpp
@@ -85,6 +85,7 @@ namespace galera
             wsrep_seqno_t current_seqno()   { return current_seqno_; }
             wsrep_seqno_t last_seqno()      { return last_seqno_; }
             bool          running()         { return running_; }
+            int           error_code()      { return error_code_; }
 #endif /* PXC */
 
         private:

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -7,6 +7,7 @@
 #include "gcs_error.hpp"
 
 #include <gu_abort.h>
+#include <gu_debug_sync.hpp>
 #include <gu_throw.hpp>
 
 /*
@@ -108,6 +109,15 @@ ReplicatorSMM::sst_received(const wsrep_gtid_t& state_id,
 
     sst_uuid_  = state_id.uuid;
     sst_seqno_ = rcode ? WSREP_SEQNO_UNDEFINED : state_id.seqno;
+
+    GU_DBUG_SYNC_EXECUTE("sst_received_decrease_state_seqno", {
+        /* Pretend that received SST is shorter.
+        IST will follow, and it will form 5 seqnos gap that should be
+        detected by Joiner */
+        sst_seqno_ = (sst_seqno_ ==  WSREP_SEQNO_UNDEFINED ?
+                      sst_seqno_ : sst_seqno_ - 5);
+    });
+
     assert(false == sst_received_);
     sst_received_ = true;
     sst_cond_.signal();
@@ -526,6 +536,12 @@ void ReplicatorSMM::process_state_req(void*       recv_ctx,
                     ((str_proto_ver < 3 || cc_lowest_trx_seqno_ == 0) ?
                     istr.last_applied() + 1 :
                     std::min(cc_lowest_trx_seqno_, istr.last_applied()+1));
+
+                GU_DBUG_SYNC_EXECUTE("serve_mimimal_ist", {
+                    wsrep_seqno_t &first_noconst =
+                        const_cast<wsrep_seqno_t&>(first);
+                    first_noconst = istr.last_applied() + 1;
+                })
 
                 try
                 {
@@ -1611,13 +1627,17 @@ void ReplicatorSMM::recv_IST(void* recv_ctx)
     {
         std::ostringstream os;
 
-        /* If IST queue was EOF that suggest IST is not going to happen
-        and DONOR (operating with old g-3 protocol) will directly send SST. */
-        if (ist_event_queue_.is_eof() && trx_proto_ver() < 3) {
-            log_info << "IST loop interrupted. Likely cause: DONOR is running"
-                     << " galera-3 or earlier protocol and has decided to"
-                     << " skip IST in favor of complete SST";
-            return;
+        if (ist_event_queue_.is_eof()) {
+            if (ist_receiver_.error_code() == EINVAL) {
+                log_info << "IST loop interrupted.";
+            } else if (trx_proto_ver() < 3) {
+                /* If IST queue was EOF that suggest IST is not going to happen
+                and DONOR (operating with old g-3 protocol) will directly send SST. */
+                log_info << "IST loop interrupted. Likely cause: DONOR is running"
+                        << " galera-3 or earlier protocol and has decided to"
+                        << " skip IST in favor of complete SST";
+                return;
+            }
         }
 
         os << "Receiving IST failed, node restart required: " << e.what();
@@ -1638,9 +1658,7 @@ void ReplicatorSMM::recv_IST(void* recv_ctx)
         }
 
         log_fatal << os.str();
-
-        gu::Lock lock(closing_mutex_);
-        start_closing();
+        abort();
     }
 }
 


### PR DESCRIPTION
…r nodes to become unresponsive

https://perconadev.atlassian.net/browse/PXC-4845

Problem:
After receiving malformed IST, Joiner node does not leave the cluster but continues. Donor node gets blocked after some time.

Cause:
Because of not ideal WSREP checkpointing mechanism it may happen that wsrep checkpoint stored in SE is lower than actually commited transaction seqno.
On the other hand, Galera is keeping track of its position in grastate.dat file, which always reflects the actual position. Let's say grastate.dat says we are at position 10, but SE checkpoint is 5.
If the node joins, and is able to join via IST, it will request missing sqno range in SST request. This is the range figured ot from grastate.dat file. So the Joiner will request seqnos > 10. Donor will skip SST and start serving seqnos > 10. At the same time, the Joiner will read SST seqno from SE. As it sees number 5, it starts IST receiver to receive > 5.
There is ongoing write traffic on Donor. It is replicated to the Joiner. But the 1st seqno received is 11. Joiner detects it and skips IST, but continues to operate.
After IST, the Joiner starts processing queued writesets (the ones that were executed on Donor while IST was in progress). As Joiner's Apply and Commit monitors are not properly initialized (both have last_left==-1), these transactions wait on Commit monitor causing applier threads to be blocked.
In the meantime the write traffic on the donor node continues. It is replicated to the Joiner node, but after short period of time, Joiner's receive queue grows up and Flow Control mechanism is activated. Donor is blocked.

Solution:
There is no good solution for storing wsrep checkpoints in SE. Some time ago we had wsrep_commit_queue on the server side, but it didn't solve this problem at all and caused deadlocks, so it was removed (server side commit a37608c7).
At the current stage, I introduced a proper handling of the problematic scenario on Galera side. The node is printing message and shutting down. PXC starting script will solve the problem by recovering Galera position from SE and stating the node with this position.