### PR TITLE
PXC-4799: PXC member used for backups fails with Inconsistency when p…

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -3403,6 +3403,102 @@ wsrep_seqno_t galera::ReplicatorSMM::pause()
     return ret;
 }
 
+#ifdef PXC
+wsrep_seqno_t galera::ReplicatorSMM::try_desync_and_pause() {
+    wsrep_seqno_t const local_seqno(
+        static_cast<wsrep_seqno_t>(gcs_.local_sequence()));
+
+    LocalOrder lo(local_seqno);
+
+    // If local monitor window would block, don't attempt to pause now.
+    if (local_monitor_.would_block(local_seqno))
+    {
+        return WSREP_SEQNO_UNDEFINED;
+    }
+
+    local_monitor_.enter(lo);
+
+    wsrep_seqno_t seqno_l;
+
+    if (local_seqno <= 0)
+    {
+        log_warn << "Invalid local_seqno : " << local_seqno;
+        local_monitor_.leave(lo);
+        return WSREP_SEQNO_UNDEFINED;
+    }
+
+    // Get drain seqno from cert index
+    wsrep_seqno_t const upto(cert_.position());
+
+    if (apply_monitor_.last_left() < upto)
+    {
+        log_warn << "Apply monitor not drained (last_left : "
+                 << apply_monitor_.last_left()
+                 << " is less then cert position : " << upto << ")";
+        local_monitor_.leave(lo);
+        return WSREP_SEQNO_UNDEFINED;
+    }
+    if (co_mode_ != CommitOrder::BYPASS &&
+        commit_monitor_.last_left() < upto)
+    {
+        log_warn << "Commit monitor not drained (last_left : "
+                 << commit_monitor_.last_left()
+                 << " is less then cert position : " << upto  << ")";
+        local_monitor_.leave(lo);
+        return WSREP_SEQNO_UNDEFINED;
+    }
+
+    ssize_t desync_ret = gcs_.desync(seqno_l);
+
+    assert(seqno_l == local_seqno+1);
+    // Failure will be handled later using desync return status.
+    // This message is to help debugging if such situation occurs.
+    if (seqno_l != local_seqno+1) {
+        log_warn << "GCS desync returned seqno " << seqno_l << ", expected "
+                 << (local_seqno + 1);
+    }
+
+    // this part is ugly, but we need to move to the next seqno returned by desync
+    local_monitor_.leave(lo);
+    LocalOrder lo2(seqno_l);
+    local_monitor_.enter(lo2);
+
+    if (desync_ret == 0)
+    {
+        if (state_() != S_DONOR) state_.shift_to(S_DONOR);
+        GU_DBUG_SYNC_WAIT("wsrep_desync_left_local_monitor");
+    }
+    else
+    {
+        log_warn << "GCS desync failed: " << -desync_ret << " ("
+                 << gcs_error_str(-desync_ret) << ")";
+        local_monitor_.leave(lo2);
+        return WSREP_SEQNO_UNDEFINED;
+    }
+    // end of desync
+    // start of pause
+    // everything without releasing local monitor
+    pause_seqno_ = seqno_l;
+
+    drain_monitors(upto);
+
+    assert (apply_monitor_.last_left() >= upto);
+    if (co_mode_ != CommitOrder::BYPASS)
+    {
+        assert (commit_monitor_.last_left() >= upto);
+        assert (commit_monitor_.last_left() == apply_monitor_.last_left());
+    }
+
+    wsrep_seqno_t const ret(last_committed());
+    st_.set(state_uuid_, ret, safe_to_bootstrap_);
+
+    log_info << "Provider paused at " << state_uuid_ << ':' << ret
+             << " (" << pause_seqno_ << ")";
+
+    return ret;
+}
+#endif /* PXC */
+
 void galera::ReplicatorSMM::resume()
 {
     if (pause_seqno_ == WSREP_SEQNO_UNDEFINED)

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -182,6 +182,9 @@ namespace galera
         const gu::Config& params() const { return config_; }
 
         wsrep_seqno_t pause();
+#ifdef PXC
+        wsrep_seqno_t try_desync_and_pause();
+#endif /* PXC */
         void          resume();
 
         void          desync();

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -1563,6 +1563,26 @@ wsrep_status_t galera_desync (wsrep_t* gh)
     }
 }
 
+#ifdef PXC
+extern "C"
+wsrep_seqno_t galera_try_desync_and_pause (wsrep_t* gh)
+{
+    assert(gh != 0);
+    assert(gh->ctx != 0);
+
+    REPL_CLASS * repl(reinterpret_cast< REPL_CLASS * >(gh->ctx));
+
+    try
+    {
+        return repl->try_desync_and_pause();
+    }
+    catch (gu::Exception& e)
+    {
+        log_warn << "Node try_desync_and_pause failed: " << e.what();
+        return WSREP_SEQNO_UNDEFINED;
+    }
+}
+#endif /* PXC */
 
 extern "C"
 wsrep_status_t galera_resync (wsrep_t* gh)
@@ -1659,6 +1679,9 @@ static wsrep_t galera_str = {
     &galera_rotate_gcache_key,
 #endif /* PXC */
     &galera_pause,
+#ifdef PXC
+    &galera_try_desync_and_pause,
+#endif /* PXC */
     &galera_resume,
     &galera_desync,
     &galera_resync,


### PR DESCRIPTION
…ending DDL clashes with FTRWL

Problem:
LOCK..BACKUP with FTWRL and DDL on remote node caused inconsistent state.

Description:
FTWRL caused MDL lock and waited for DDL to finish in the PXC. FTWRL specifically waits in desync_and_pause->pause statement waiting for concurrent pause statement to finish.

Resolution:
DDLs cannot be executed in parallel with FTWRL in local node it will fail. So on local node ER_CANT_UPDATE_WITH_READLOCK is seen post FTWRL FLUSH TABLES WITH READ LOCK;
--error ER_CANT_UPDATE_WITH_READLOCK
CREATE TABLE t1 (id INT PRIMARY KEY, a INT);
However in PXC remote node not aware of FTWRL on another node accepts the DDL and sends across the cluster opening a pandora of unknown conditions. So, we prevent FLUSH TABLES WITH READ LOCK when the session already holds explicit table locks.
We also check that pause will block; with ongoing TO isolation, MDL locks are likely to conflict with FTWRL, so it is best to fail FTWRL. By rejecting FLUSH TABLES WITH READ LOCK in this situation, we avoid the deadlock-like condition and allow the remote DDL to proceed to avoid situations like below:
NODE-2
LOCK INSTANCE FOR BACKUP;
NODE-1
CREATE TABLE t_synch1 (id INT PRIMARY KEY, a INT); NODE-2
FLUSH TABLES WITH READ LOCK;
NODE-2
UNLOCK TABLE;
UNLOCK INSTANCE;
NOTE: Even with this safeguard, if the DDL waiting for MDL exceeds lock_wait_timeout, the DDL will fail while waiting for the maitenance operations to finish. FLUSH or DDL will not block so the session can execute UNLOCK for the DDL to complete.
This behavior is specific to PXC. In standalone PS/PXC servers, such conflicting operations fail naturally, but in multi-node PXC deployments, DDL may arrive from another node, making this protection necessary.