### PR TITLE
PXC-4683: Node leaves the cluster after an error in a stored procedure

### DIFF
--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #endif /* PXC */
 
+#include <algorithm>
 #include <cinttypes>
 #include <limits>
 #include <regex>
@@ -1075,6 +1076,17 @@ group_recount_votes (gcs_group_t& group)
     return true;
 }
 
+/* Error codes that must not affect voting
+   (e.g. 1681 has been deprecated without replacement)
+   (also 1681 warning can differ across nodes). */
+static bool ignore_error_code_for_voting(const std::string& code)
+{
+    /* Keep below list sorted. */
+    static const std::vector<std::string> ignore_error_codes= {"1681"};
+    return std::binary_search(ignore_error_codes.begin(),
+                    ignore_error_codes.end(), code);
+}
+
 /* Function to recompute vote based on only on the error code */
 int64_t recompute_vote_based_on_error_code (const gu::GTID& gtid,
                                             const std::string& err_msg,
@@ -1098,7 +1110,11 @@ int64_t recompute_vote_based_on_error_code (const gu::GTID& gtid,
     {
         // Extract the error code
         std::smatch match = *it;
-        matchedErrorCodes.push_back(match[1].str());
+        std::string code(match[1].str());
+
+        // skip error codes that must not affect voting
+        if (!ignore_error_code_for_voting(code))
+          matchedErrorCodes.push_back(std::move(code));
         ++it;
     }
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4683

Problem: ER_WARN_DEPRECATED_SYNTAX_NO_REPLACEMENT(1681) warning causes inconsistency.
TOI-failed inside a stored procedure e.g. ALTER TABLE on a non-existing table with tinyint marked the node inconsistent due to additional 1681 warning.

Description:
TOI failure in a stored procedure (e.g. ALTER TABLE on non-existing table with tinyint) could mark the node inconsistent. The voting payload included warning 1681 (Integer display width is deprecated..) in addition to the error 1146. Warning 1681 was logged in client side while 1681 warning was not being logged via replication channels. The difference in error and warnings in different nodes caused inconsistency causing one of the node i.e. recipient of transaction to leave the cluster.

Cause:
The Galera wsrep_store_error consider the diagnostics area in addition to the real error code. Deprecated integer display width (tinyint(1) -> warning 1681), nodes produce different condition lists (1146 vs 1146+1681), leading to different vote and eventually causing inconsistency.

Fix:
Ignore the ER_WARN_DEPRECATED_SYNTAX_NO_REPLACEMENT and do not send it across cluster.