### PR TITLE
PXC-5209: Corrupted Galera Caches Causes PXC to OOM

### DIFF
--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -18,7 +18,9 @@
 #include <gu_crc.hpp>
 
 #include <cassert>
-#include <iostream> // std::cerr
+#include <iostream>  // std::cerr
+#include <sstream>   // std::ostringstream
+#include <stdexcept> // std::runtime_error
 
 namespace gcache
 {
@@ -1026,7 +1028,9 @@ namespace gcache
 
                 try
                 {
-                    recover(offset - (start_ - preamble), version);
+                    recover(offset - (start_ - preamble), version,
+                            static_cast<seqno_t>(seqno_min),
+                            static_cast<seqno_t>(seqno_max));
                 }
                 catch (gu::Exception& e)
                 {
@@ -1070,8 +1074,66 @@ namespace gcache
         ProgressCallback* pcb_;
     };
 
+    void
+    RingBuffer::do_sanity_checks(BufferHeader* bh,
+                                 seqno_t const seqno_g,
+                                 seqno_t const preamble_seqno_min,
+                                 seqno_t const preamble_seqno_max) const
+    {
+        /* Sanity check on bh->size. A corrupted gcache may
+         * have a buffer header which advertises size
+         * payload larger than the entire cache.
+         * GCACHE_SCAN_BUFFER_TEST guarantees that bh->size fits within the
+         * buffer (ptr + bh->size <= segment_end), so bh->size > size_cache_
+         * cannot happen when do_sanity_check() is called after that macro.
+         * The condition is kept as a defensive check for future use, in case
+         * do_sanity_check() is called without a preceding
+         * GCACHE_SCAN_BUFFER_TEST.*/
+        if (bh->size > size_cache_)
+        {
+            std::ostringstream os;
+            os << "implausible bh->size " << bh->size
+               << " exceeds cache size " << size_cache_
+               << ", cache appears to be corrupt";
+            throw std::runtime_error(os.str());
+        }
+        /* Sanity check on bh->seqno_g: a corrupted gcache.cache may contain
+         * buffer headers with corrupted seqno_g values. */
+        seqno_t const max_seqnos(
+            static_cast<seqno_t>(size_cache_ / sizeof(BufferHeader)) + 1);
+        if (preamble_seqno_min != SEQNO_ILL &&
+            preamble_seqno_max != SEQNO_ILL &&
+            (seqno_g > preamble_seqno_max + max_seqnos ||
+             seqno_g < preamble_seqno_min - max_seqnos))
+        {
+            std::ostringstream os;
+            os << "implausible seqno " << seqno_g
+               << " is outside preamble range ["
+               << preamble_seqno_min << ", " << preamble_seqno_max
+               << "] (epsilon " << max_seqnos
+               << "), cache appears to be corrupt";
+            throw std::runtime_error(os.str());
+        }
+
+        if (!seqno2ptr_.empty() &&
+            (seqno_g > seqno2ptr_.index_back() + max_seqnos ||
+             seqno_g < seqno2ptr_.index_front() - max_seqnos))
+        {
+            std::ostringstream os;
+            os << "implausible seqno " << seqno_g
+               << " for cache range ["
+               << seqno2ptr_.index_front() << ", "
+               << seqno2ptr_.index_back()
+               << "] (max gap " << max_seqnos
+               << "), cache appears to be corrupt";
+            throw std::runtime_error(os.str());
+        }
+    }
+
     seqno_t
-    RingBuffer::scan(off_t const offset, int const scan_step)
+    RingBuffer::scan(off_t const offset, int const scan_step,
+                     seqno_t const preamble_seqno_min,
+                     seqno_t const preamble_seqno_max)
     {
         int segment_scans(0);
         seqno_t seqno_max(SEQNO_ILL);
@@ -1205,6 +1267,11 @@ namespace gcache
                     {
                         try
                         {
+                            /* Reject corrupted seqno_g values before inserting
+                             * into seqno2ptr_. */
+                            do_sanity_checks(bh, seqno_g, preamble_seqno_min,
+                                             preamble_seqno_max);
+
                             seqno2ptr_.insert(seqno_g, bh + 1);
                         }
                         catch (std::exception& e)
@@ -1356,12 +1423,18 @@ namespace gcache
     }
 
     void
-    RingBuffer::recover(off_t const offset, int version)
+    RingBuffer::recover(off_t const offset, int version,
+                        seqno_t const preamble_seqno_min,
+                        seqno_t const preamble_seqno_max)
     {
         static const char* const diag_prefix ="Recovering GCache ring buffer: ";
 
         /* scan the buffer and populate seqno2ptr map */
-        seqno_t const lowest(scan(offset, version > 0 ? MemOps::ALIGNMENT : 1)
+        /* pr_seqno_min and pr_seqno_max are forwarded so scan() can reject
+         * buffer headers whose seqno_g is outside the range. */
+
+        seqno_t const lowest(scan(offset, version > 0 ? MemOps::ALIGNMENT : 1,
+                                  preamble_seqno_min, preamble_seqno_max)
                              + 1);
         /* lowest is the lowest valid seqno based on collisions during scan */
 

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -239,9 +239,26 @@ namespace gcache
         void          open_preamble(bool recover);
         void          close_preamble();
 
-        // returns lower bound (not inclusive) of valid seqno range
-        seqno_t       scan(off_t offset, int scan_step);
-        void          recover(off_t offset, int version);
+        // returns lower bound (not inclusive) of valid seqno range.
+        //
+        // preamble_seqno_min / preamble_seqno_max are the seqno_min /
+        // seqno_max values read from the on-disk preamble (the bounds
+        // recorded by the last clean shutdown). Pass SEQNO_ILL for either
+        // when no preamble bound is available; in that case scan() falls
+        // back to the looser size-based plausibility check.
+        seqno_t       scan(off_t offset, int scan_step,
+                           seqno_t preamble_seqno_min,
+                           seqno_t preamble_seqno_max);
+        void          recover(off_t offset, int version,
+                              seqno_t preamble_seqno_min,
+                              seqno_t preamble_seqno_max);
+        // Validates a recovered buffer's seqno_g against the preamble
+        // bounds and the seqnos already mapped in seqno2ptr_. Throws
+        // std::runtime_error when seqno_g is implausible.
+        void          do_sanity_checks(BufferHeader* bh,
+                                       seqno_t seqno_g,
+                                       seqno_t preamble_seqno_min,
+                                       seqno_t preamble_seqno_max) const;
 
         void          estimate_space(bool zero_out = false);
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-5209

When a node restarts with gcache.recover=yes, RingBuffer::scan() walks the on-disk galera.cache and rebuilds the seqno2ptr_ map. The scan trusted the BufferHeader metadata read from disk: BH_test() only checks that the recorded size is at least sizeof(BufferHeader), and seqno_g is not validated. A truncated or otherwise corrupted cache could therefore present a buffer header whose size advertised a payload larger than the whole cache, or a seqno_g outside range.

Two failure modes follow from this:

  - A large bh->size makes ptr + bh->size look like the start of the next valid header, so the scan keeps "recovering" garbage and a bad pointer is later handed to GCache::free_common()

  - A corrupted seqno_g (e.g. 10^12) is inserted into the seqno2ptr_ deque, which then tries to allocate an enormous index range. On a memory-constrained host this may reported OOM kill or may throw std::bad_alloc

Fix (percona-xtradb-cluster-galera):

  - Tighten GCACHE_SCAN_BUFFER_TEST so a header is accepted only when bh->size is greater than zero and does not exceed either the cache size or the bytes remaining in the current segment
  - Before inserting into seqno2ptr_, reject a header whose bh->size exceeds the cache, whose seqno_g falls outside the [seqno_min, seqno_max] range
  - Forward the preamble's seqno_min / seqno_max bounds from recover() into scan() so the preamble-anchored check can run even for the very first buffer, when seqno2ptr_ is still empty.
  - log the corruption in such cases, clear the recovered state and force a full reset