### PR TITLE
PXC-4932: Merge PS 8.4.10-10(resolve compilation failure)

### DIFF
--- a/gcs/src/gcs_group.cpp
+++ b/gcs/src/gcs_group.cpp
@@ -599,7 +599,6 @@ gcs_group_handle_comp_msg (gcs_group_t* group, const gcs_comp_msg_t* comp)
 {
     long        new_idx, old_idx;
     gcs_node_t* new_nodes = NULL;
-    ulong       new_memb  = 0;
 
     const bool prim_comp     = gcs_comp_msg_primary  (comp);
     const bool bootstrap     = gcs_comp_msg_bootstrap(comp);
@@ -717,9 +716,6 @@ gcs_group_handle_comp_msg (gcs_group_t* group, const gcs_comp_msg_t* comp)
                 break;
             }
         }
-        /* if wasn't found in new configuration, new member -
-         * need to do state exchange */
-        new_memb |= (old_idx == group->num);
     }
 
     /* free old nodes array */


### PR DESCRIPTION
Post commit be1909593c15505ef4f0479b4afdf6c254d78c3b, usage of the variable new_memb was removed but it's declation and assignment remained in the code causing compilation failure. Removed the left over code related to new_memb.