### PR TITLE
PXC-4932: Fix cmake failure with RPM layout when INSTALL_DOCDIR is empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,8 @@ add_subdirectory(scripts/packages)
 add_subdirectory(wsrep/tests)
 
 # Make the install destination for documentation files configurable
-if(NOT DEFINED INSTALL_DOCDIR)
-  set(INSTALL_DOCDIR "doc" CACHE STRING "path to install documentation to")
+if(NOT INSTALL_DOCDIR)
+  set(INSTALL_DOCDIR "doc" CACHE STRING "path to install documentation to" FORCE)
 endif()
 
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")


### PR DESCRIPTION
Problem
-------
Building PXC with -DINSTALL_LAYOUT=RPM fails at cmake configure time with the following errors:

  CMake Error at percona-xtradb-cluster-galera/CMakeLists.txt:137 (install):
    install FILES given no DESTINATION!

  CMake Error at percona-xtradb-cluster-galera/CMakeLists.txt:141 (install):
    install FILES given no DESTINATION!

Root cause
----------
In mysql/cmake/install_layout.cmake, INSTALL_DOCDIR_RPM is intentionally left unset (commented out at line 234):

  #SET(INSTALL_DOCDIR_RPM  unset - installed directly by RPM)

The FOREACH loop at lines 317-342 of cmake/install_layout.cmake iterates over all install directory variables including DOC:

  FOREACH(var BIN DOC DOCREADME INCLUDE ...)
    SET(INSTALL_${var}DIR
      ${INSTALL_${var}DIR_${INSTALL_LAYOUT}}   <- expands to ${INSTALL_DOCDIR_RPM}
      CACHE STRING ...)
  ENDFOREACH()

Since INSTALL_DOCDIR_RPM is never defined, cmake expands it to an empty string "", effectively writing INSTALL_DOCDIR="" into the cmake cache before the galera CMakeLists.txt runs.

MGL-163 added this guard:
  if(NOT DEFINED INSTALL_DOCDIR)
    set(INSTALL_DOCDIR "doc" CACHE STRING "...")
  endif()

Since INSTALL_DOCDIR IS defined (as "") by the parent cmake FOREACH loop, NOT DEFINED evaluates to FALSE and the reset to "doc" is never performed.

Fix
---
Two changes:

1. Change the guard from if(NOT DEFINED INSTALL_DOCDIR) to if(NOT INSTALL_DOCDIR) so it correctly handles both "undefined" and "defined as empty string"

2. Add FORCE to the set() call so it actually overrides the cached "" value written by the parent cmake. Without FORCE the set() is silently ignored when the variable already exists in the cache. With FORCE, INSTALL_DOCDIR is always non-empty after the guard block ("doc" as default, or the parent's value if non-empty), so the install() calls below always have a valid DESTINATION.

Failing cmake command
---------------------
  cmake ../ -DINSTALL_LAYOUT=RPM -DWITH_WSREP=ON [...]