### PR TITLE
PXC-5208: Force SST after inconsistency eviction

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -185,6 +185,10 @@ galera::ReplicatorSMM::ReplicatorSMM(const struct wsrep_init_args* args)
     commit_monitor_     (),
 #endif /* HAVE_PSI_INTERFACE */
     causal_read_timeout_(config_.get(Param::causal_read_timeout)),
+#ifdef PXC
+    force_sst_after_inconsistency_(
+        config_.get<bool>(Param::force_sst_after_inconsistency)),
+#endif /* PXC */
     receivers_          (),
     replicated_         (),
     replicated_bytes_   (),
@@ -496,7 +500,9 @@ wsrep_status_t galera::ReplicatorSMM::async_recv(void* recv_ctx)
         {
             if (GcsActionSource::INCONSISTENCY_CODE == rc)
             {
-                st_.mark_corrupt();
+                // Mark node corrupt and initiate cluster leave due to
+                // inconsistency
+                mark_corrupt_and_close();
                 retval = WSREP_FATAL;
             }
             else

--- a/galera/src/replicator_smm.hpp
+++ b/galera/src/replicator_smm.hpp
@@ -388,7 +388,19 @@ namespace galera
         void mark_corrupt_and_close()
         /* mark state as corrupt and try to leave cleanly */
         {
+#ifdef PXC
+            /*
+              Remove grastate.dat on shutdown to force a full SST on the next
+              startup.
+              The repl.force_sst_after_inconsistency option controls this
+              behavior: when enabled, the state file is removed; when disabled
+              (default), it is preserved to retain the previous behavior and
+              helps investigation.
+            */
+            st_.mark_corrupt(force_sst_after_inconsistency_);
+#else
             st_.mark_corrupt();
+#endif /* PXC */
             gu::Lock lock(closing_mutex_);
             start_closing();
         }
@@ -434,6 +446,9 @@ namespace galera
             static const std::string commit_order;
             static const std::string causal_read_timeout;
             static const std::string max_write_set_size;
+#ifdef PXC
+            static const std::string force_sst_after_inconsistency;
+#endif /* PXC */
         };
 
         typedef std::pair<std::string, std::string> Default;
@@ -1212,6 +1227,15 @@ namespace galera
         Monitor<ApplyOrder>  apply_monitor_;
         Monitor<CommitOrder> commit_monitor_;
         gu::datetime::Period causal_read_timeout_;
+#ifdef PXC
+        /*
+          repl.force_sst_after_inconsistency: when enabled, a node that leaves
+          the cluster due to an inconsistency removes grastate.dat, forcing a
+          full SST on the next startup. When disabled (default), the state file
+          is not removed.
+        */
+        bool                 force_sst_after_inconsistency_;
+#endif /* PXC */
 
         // counters
         gu::Atomic<size_t>    receivers_;

--- a/galera/src/replicator_smm_params.cpp
+++ b/galera/src/replicator_smm_params.cpp
@@ -24,6 +24,10 @@ const std::string galera::ReplicatorSMM::Param::key_format =
     common_prefix + "key_format";
 const std::string galera::ReplicatorSMM::Param::max_write_set_size =
     common_prefix + "max_ws_size";
+#ifdef PXC
+const std::string galera::ReplicatorSMM::Param::force_sst_after_inconsistency =
+    common_prefix + "force_sst_after_inconsistency";
+#endif /* PXC */
 
 int const galera::ReplicatorSMM::MAX_PROTO_VER(11);
 
@@ -38,6 +42,13 @@ galera::ReplicatorSMM::Defaults::Defaults() : map_()
     const int max_write_set_size(galera::WriteSetNG::MAX_SIZE);
     map_.insert(Default(Param::max_write_set_size,
                         gu::to_string(max_write_set_size)));
+#ifdef PXC
+    /*
+      Off by default: keep the historical behaviour of leaving grastate.dat
+      in place.
+    */
+    map_.insert(Default(Param::force_sst_after_inconsistency, "no"));
+#endif /* PXC */
 }
 
 const galera::ReplicatorSMM::Defaults galera::ReplicatorSMM::defaults;
@@ -62,6 +73,10 @@ galera::ReplicatorSMM::InitConfig::InitConfig(gu::Config&       conf,
 
     conf.set_flags(Param::causal_read_timeout, gu::Config::Flag::type_duration);
     conf.set_flags(Param::max_write_set_size, gu::Config::Flag::type_integer);
+#ifdef PXC
+    conf.set_flags(Param::force_sst_after_inconsistency,
+                   gu::Config::Flag::type_bool);
+#endif /* PXC */
     conf.set_flags(Param::base_dir, gu::Config::Flag::read_only);
     conf.set_flags(Param::base_port, gu::Config::Flag::read_only |
                    gu::Config::Flag::type_integer);
@@ -192,6 +207,12 @@ galera::ReplicatorSMM::set_param (const std::string& key,
     {
         trx_params_.max_write_set_size_ = gu::from_string<int>(value);
     }
+#ifdef PXC
+    else if (key == Param::force_sst_after_inconsistency)
+    {
+        force_sst_after_inconsistency_ = gu::Config::from_config<bool>(value);
+    }
+#endif /* PXC */
     else
     {
         log_warn << "parameter '" << key << "' not found";

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -1600,7 +1600,16 @@ void ReplicatorSMM::process_IST_writeset(void* recv_ctx,
     }
     catch (...)
     {
+#ifdef PXC
+        /*
+          Applying an IST writeset failed, if
+          repl.force_sst_after_inconsistency is enabled remove the grastate.dat
+          state file to force SST.
+        */
+        st_.mark_corrupt(force_sst_after_inconsistency_);
+#else
         st_.mark_corrupt();
+#endif /* PXC */
         throw;
     }
     GU_DBUG_SYNC_WAIT("recv_IST_after_apply_trx");
@@ -1700,6 +1709,10 @@ void ReplicatorSMM::recv_IST(void* recv_ctx)
             break;
         }
 
+#ifdef PXC
+        // Drop grastate.dat and force SST on the next start.
+        st_.mark_corrupt(force_sst_after_inconsistency_);
+#endif /* PXC */
         log_fatal << os.str();
         abort();
     }

--- a/galera/src/saved_state.cpp
+++ b/galera/src/saved_state.cpp
@@ -296,19 +296,32 @@ SavedState::mark_safe()
     }
 }
 
+#ifdef PXC
+void
+SavedState::mark_corrupt(bool remove_state_file)
+#else
 void
 SavedState::mark_corrupt()
+#endif /* PXC */
 {
     gu::Lock lock(mtx_); ++total_locks_;
 
-    if (corrupt_) return;
+    if (!corrupt_)
+    {
+        uuid_  = WSREP_UUID_UNDEFINED;
+        seqno_ = WSREP_SEQNO_UNDEFINED;
+        corrupt_ = true;
 
-    uuid_  = WSREP_UUID_UNDEFINED;
-    seqno_ = WSREP_SEQNO_UNDEFINED;
-    corrupt_ = true;
+        write_file (WSREP_UUID_UNDEFINED, WSREP_SEQNO_UNDEFINED,
+                    safe_to_bootstrap_);
+    }
 
-    write_file (WSREP_UUID_UNDEFINED, WSREP_SEQNO_UNDEFINED,
-                safe_to_bootstrap_);
+#ifdef PXC
+    if (remove_state_file)
+    {
+        unlink_state_file();
+    }
+#endif /* PXC */
 }
 
 void
@@ -325,6 +338,27 @@ SavedState::mark_uncorrupt(const wsrep_uuid_t& u, wsrep_seqno_t s)
 
     write_file (u, s, safe_to_bootstrap_);
 }
+
+#ifdef PXC
+/* Caller must hold mtx_. */
+void
+SavedState::unlink_state_file()
+{
+    if (::unlink(filename_.c_str()) == 0)
+    {
+        log_info << "Removed state file '" << filename_
+                 << "' because the node left the cluster due to an "
+                    "inconsistency. The node will request a full SST "
+                    "on the next start.";
+    }
+    else if (errno != ENOENT)
+    {
+        log_warn << "Could not remove state file '" << filename_
+                 << "': " << ::strerror(errno)
+                 << ". Remove it manually to force SST on the next start.";
+    }
+}
+#endif /* PXC */
 
 void
 SavedState::write_file(const wsrep_uuid_t& u, const wsrep_seqno_t s,

--- a/galera/src/saved_state.hpp
+++ b/galera/src/saved_state.hpp
@@ -30,7 +30,15 @@ public:
 
     void mark_unsafe();
     void mark_safe();
+#ifdef PXC
+    /*
+     Mark the state as corrupt.
+     When remove_state_file is true the state file is unlinked as well.
+    */
+    void mark_corrupt(bool remove_state_file = false);
+#else
     void mark_corrupt();
+#endif /* PXC */
     void mark_uncorrupt(const wsrep_uuid_t& u, wsrep_seqno_t s);
 
     bool corrupt() const { return corrupt_; }
@@ -75,6 +83,11 @@ private:
 
     void write_file (const wsrep_uuid_t& u, const wsrep_seqno_t s,
                      bool safe_to_bootstrap);
+
+#ifdef PXC
+    /* Unlink the state file. Caller must hold mtx_. */
+    void unlink_state_file();
+#endif /* PXC */
 
     SavedState (const SavedState&);
     SavedState& operator=(const SavedState&);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-5208

When a node is voted out of the cluster due to a data inconsistency, remove grastate.dat on shutdown so the node is forced to perform a full SST on the next start instead of IST, which would otherwise resurrect the inconsistent dataset via --wsrep-recover.