### PR TITLE
DO NOT MERGE — raised from the CI-only branch; replaced (PXC-5267 galera for PXC 8.4.11-11)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "wsrep-API"]
 	path = wsrep/src
-	url = https://github.com/percona/wsrep-API.git
+	url = https://github.com/jaideepkarande/wsrep-API.git
 	branch = percona-4.x-8.0
 

--- a/.jenkins/pr-galera-4.x-review.groovy
+++ b/.jenkins/pr-galera-4.x-review.groovy
@@ -7,14 +7,17 @@ pipeline {
     stage ('Smoke Test') {
       steps {
         script {
-          def res = sh(script: "echo -e \"$ghprbPullLongDescription\" | grep '^MYSQL_BRANCH=' ||:",
-                                returnStdout: true)
-          if (!res.isEmpty()) {
-            env.MYSQL_BRANCH = res.split('=')[1].trim()
+          def desc = ghprbPullLongDescription.replace('\\r', '').replace('\\n', '\n')
+          def branchLine = desc.readLines().find { it.startsWith('MYSQL_BRANCH=') }
+          if (branchLine) {
+            def mysqlBranch = branchLine.substring('MYSQL_BRANCH='.length()).trim()
+            if (!(mysqlBranch ==~ /[A-Za-z0-9._\/-]+/)) {
+              error "Invalid MYSQL_BRANCH value in PR description: ${mysqlBranch}"
+            }
+            env.MYSQL_BRANCH = mysqlBranch
           } else {
             env.MYSQL_BRANCH = env.DEFAULT_MYSQL_BRANCH
           }
-          echo sh(script: 'env|sort', returnStdout: true)
 
           build job: 'pr-galera-4.x-smoke-test', wait: true,
                   parameters: [ string(name: 'GALERA_BRANCH', value: env.ghprbActualCommit )]


### PR DESCRIPTION
> [!WARNING]
> **Do not merge. This PR was raised from the wrong branch and is being replaced.**
>
> Its head is `PXC_5267-ci`, a throwaway branch created only so Jenkins could build the release. The correct head is `PXC_5267`.

## What is wrong with it

The head commit, [`63fd5ed`](https://github.com/percona/galera/commit/63fd5ed9a0adf4e4f66ca8e61375b3e2171cbf52), changes `.gitmodules`:

```diff
-	url = https://github.com/percona/wsrep-API.git
+	url = https://github.com/jaideepkarande/wsrep-API.git
```

Merging that would leave `4.x-8.0` fetching its wsrep-API submodule from a personal fork, for everyone who clones this repo. The commit says `DO NOT MERGE` in its own message; it exists only because the PXC-5267 wsrep-API sha `f80a23b6642` is not yet in `percona/wsrep-API`, so a plain `git submodule update` cannot resolve it from CI.

GitHub does not allow a PR's head branch to be changed, so this one is closed rather than corrected in place.

## What this release actually needs reviewed

The same work, minus the CI commit, on `PXC_5267` (`6f220727a7d`):

| Commit | |
|---|---|
| `a8b6b4c` | `Fix fragile branch name parsing` — the single commit `maria_galera/4.x` brings in |
| `2604a15` | `PXC-5267: Merge galera 4.x for PXC 8.4.11-11 (maria_galera/4.x@a8b6b4c3)` |
| `6f22072` | `PXC-5267: Update wsrep-API submodule` — pointer bump for the release |

`maria_galera/25.3.12` was already contained in `percona/4.x-8.0` and produced no commit.

**Replacement: #317**, same work from `PXC_5267`, draft, reviewer requested.
