### PR TITLE
PXC-5267: Code refresh for - PXC 8.4.11-11

### DIFF
--- a/.jenkins/pr-galera-4.x-review.groovy
+++ b/.jenkins/pr-galera-4.x-review.groovy
@@ -7,14 +7,17 @@ pipeline {
     stage ('Smoke Test') {
       steps {
         script {
-          def res = sh(script: "echo -e \"$ghprbPullLongDescription\" | grep '^MYSQL_BRANCH=' ||:",
-                                returnStdout: true)
-          if (!res.isEmpty()) {
-            env.MYSQL_BRANCH = res.split('=')[1].trim()
+          def desc = ghprbPullLongDescription.replace('\\r', '').replace('\\n', '\n')
+          def branchLine = desc.readLines().find { it.startsWith('MYSQL_BRANCH=') }
+          if (branchLine) {
+            def mysqlBranch = branchLine.substring('MYSQL_BRANCH='.length()).trim()
+            if (!(mysqlBranch ==~ /[A-Za-z0-9._\/-]+/)) {
+              error "Invalid MYSQL_BRANCH value in PR description: ${mysqlBranch}"
+            }
+            env.MYSQL_BRANCH = mysqlBranch
           } else {
             env.MYSQL_BRANCH = env.DEFAULT_MYSQL_BRANCH
           }
-          echo sh(script: 'env|sort', returnStdout: true)
 
           build job: 'pr-galera-4.x-smoke-test', wait: true,
                   parameters: [ string(name: 'GALERA_BRANCH', value: env.ghprbActualCommit )]


### PR DESCRIPTION
Galera submodule refresh for the **PXC 8.4.11-11** release ([PXC-5267](https://perconadev.atlassian.net/browse/PXC-5267)).

## What this merges

| Ref | Sha | Brings |
|---|---|---|
| `mariadb-corporation/galera` `4.x` | `a8b6b4c3` | one commit — *Fix fragile branch name parsing* |
| `mariadb-corporation/galera` `25.3.12` | — | **already contained** in `percona/4.x-8.0`; produced no commit |

`25.3.12` is called out explicitly because silence there reads as a step nobody got to, rather than one that was checked and needed nothing.

**No conflicts.** The `4.x` merge applied cleanly; there is no hand-resolution to review.

## Submodule pointer

| Path | Before → After |
|---|---|
| `wsrep/src` (wsrep-API) | `7fe08ed3334` → `f80a23b6642` |

That bump carries `mariadb/master@cf9c0a2c` into wsrep-API. All five commits it brings are upstream `Merge branch 'v26'` up-merges that carry no files of their own — verified with `git show --cc` — so wsrep-API's **tree is unchanged**; the bump records provenance rather than a code change. `mariadb/v26` was likewise already contained.

## Merge order — this matters

```
percona/wsrep-API#15   →   percona/galera (this PR)   →   percona/percona-xtradb-cluster#2349
```

The pointer above references `f80a23b6642`, which currently exists only on `jaideepkarande/wsrep-API`. Until the wsrep-API PR merges, a clone of `percona/galera` at this branch cannot `git submodule update`. So the wsrep-API PR merges first, this one second, and the PXC release PR last.

## Validation

Galera is not built standalone here — it is exercised through the PXC release runs of `pxc-8.x-pipeline-parallel-mtr`, which build this exact galera sha as a submodule:

| Config | Run | Result |
|---|---|---|
| Debug | [#884](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/884/) | 8 failures vs 10 in its baseline |
| RelWithDebInfo | [#885](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/885/) | 4 vs 3 |
| ASAN | [#886](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/886/) | 35 vs 38 — **not comparable**, one worker did not run |
| Valgrind | [#887](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/887/) | running |

`UNSTABLE` is the normal outcome of that job; the gate is no new failures against the paired baseline, not the colour of the ball. None of the failures still open against the release trace to galera — the two that were ours were a PS assertion and a PS-changed test expectation, both fixed on the PXC side. Full analysis lives on [#2349](https://github.com/percona/percona-xtradb-cluster/pull/2349).

## Related

- [percona/percona-xtradb-cluster#2349](https://github.com/percona/percona-xtradb-cluster/pull/2349) — the PXC 8.4.11-11 release that consumes this
- percona/wsrep-lib#29 — the sibling wsrep-lib refresh
- #316 — an earlier attempt raised from the throwaway CI branch, closed unmerged. It carried a `.gitmodules` change repointing wsrep-API at a personal fork, which exists purely so Jenkins can resolve the submodule before the wsrep-API PR lands.

## Before this leaves draft

1. The wsrep-API PR raised and merged, so the pointer resolves in `percona/wsrep-API`.
2. Valgrind read, and ASAN re-run so that all workers execute.


[PXC-5267]: https://perconadev.atlassian.net/browse/PXC-5267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ